### PR TITLE
Set up GitHub Actions workflow for periodic metadata updates

### DIFF
--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -41,8 +41,8 @@ jobs:
           branch: automation/update-metadata-parquet
           base: ${{ github.event.repository.default_branch }}
           delete-branch: true
-          commit-message: chore: update metadata parquet
-          title: chore: update metadata parquet
+          commit-message: "chore: update metadata parquet"
+          title: "chore: update metadata parquet"
           body: |
             Automated refresh of metadata Parquet files.
 


### PR DESCRIPTION
## Summary
- add `.github/workflows/update-metadata.yml`
- run weekly on Monday 00:00 UTC and support manual dispatch
- generate metadata Parquet files via `uv run boj-stat-search generate-metadata-parquet`
- create/update an automated PR with only `metadata/*.parquet` changes

## Why
- automate metadata refresh without direct pushes to protected branches

## Validation
- workflow YAML reviewed for schedule/manual trigger, permissions, and PR-based update path

Closes #13