### PR TITLE
Add local catalog loader with TTL-based Parquet caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ show_layers(metadata.result_set, layer="1,1")
 boj-stat-search generate-metadata-parquet --output-dir metadata
 ```
 
+```python
+from boj_stat_search import load_catalog_db
+
+# Download/cache metadata/FM01.parquet locally (24h TTL by default)
+fm01_catalog = load_catalog_db("FM01")
+print(fm01_catalog.num_rows)
+```
+
 ## Documentation
 
 - [User Guide](./docs/user_guide/README.md)

--- a/docs/user_guide/README.md
+++ b/docs/user_guide/README.md
@@ -5,7 +5,7 @@ This guide explains how to use `boj_stat_search` for common tasks.
 The package can be used in three ways:
 
 - **CLI** — the `boj-stat-search` command lets you query data directly from the terminal. JSON output is designed for piping to `jq` and other tools.
-- **Functional API** — top-level functions (`get_metadata`, `get_data_code`, `get_data_layer`, `generate_metadata_parquet_files`). Simple and composable; no built-in throttling, so callers must manage delays manually for batch use.
+- **Functional API** — top-level functions (`get_metadata`, `get_data_code`, `get_data_layer`, `generate_metadata_parquet_files`, `load_catalog_db`, `load_catalog_all`). Simple and composable; no built-in throttling, so callers must manage delays manually for batch use.
 - **`BojClient`** — a stateful client that wraps the functional API. Reuses a single HTTP connection and enforces a configurable minimum delay between requests (default 1 s). Preferred for batch workflows.
 
 ## Who This Is For
@@ -28,6 +28,8 @@ The package can be used in three ways:
   - `get_data_code`
   - `get_data_layer`
   - `generate_metadata_parquet_files`
+  - `load_catalog_db`
+  - `load_catalog_all`
   - `BojClient` (stateful client with built-in throttling)
   - `show_layers`
   - `list_db`

--- a/src/boj_stat_search/__init__.py
+++ b/src/boj_stat_search/__init__.py
@@ -8,7 +8,15 @@ from boj_stat_search.api import (
     get_metadata,
     get_metadata_raw,
 )
-from boj_stat_search.catalog import MetadataExportReport, generate_metadata_parquet_files
+from boj_stat_search.catalog import (
+    CatalogCacheError,
+    CatalogError,
+    CatalogFetchError,
+    MetadataExportReport,
+    generate_metadata_parquet_files,
+    load_catalog_all,
+    load_catalog_db,
+)
 from boj_stat_search.core import Frequency, Layer, Period, list_db
 from boj_stat_search.display import show_layers
 from boj_stat_search.models import (
@@ -29,10 +37,15 @@ __all__ = [
     "get_data_layer_raw",
     "get_data_layer",
     "generate_metadata_parquet_files",
+    "load_catalog_db",
+    "load_catalog_all",
     "Frequency",
     "Layer",
     "Period",
     "MetadataExportReport",
+    "CatalogError",
+    "CatalogFetchError",
+    "CatalogCacheError",
     "BaseResponse",
     "DbInfo",
     "MetadataEntry",

--- a/src/boj_stat_search/catalog/__init__.py
+++ b/src/boj_stat_search/catalog/__init__.py
@@ -5,6 +5,13 @@ from boj_stat_search.catalog.exporter import (
     metadata_entries_to_rows,
     write_metadata_parquet,
 )
+from boj_stat_search.catalog.loader import (
+    CatalogCacheError,
+    CatalogError,
+    CatalogFetchError,
+    load_catalog_all,
+    load_catalog_db,
+)
 
 __all__ = [
     "METADATA_PARQUET_COLUMNS",
@@ -12,4 +19,9 @@ __all__ = [
     "generate_metadata_parquet_files",
     "metadata_entries_to_rows",
     "write_metadata_parquet",
+    "CatalogError",
+    "CatalogFetchError",
+    "CatalogCacheError",
+    "load_catalog_db",
+    "load_catalog_all",
 ]

--- a/src/boj_stat_search/catalog/loader.py
+++ b/src/boj_stat_search/catalog/loader.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from urllib.parse import quote
+
+import httpx
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from boj_stat_search.core import list_db
+
+DEFAULT_CACHE_TTL_SECONDS = 24 * 60 * 60
+DEFAULT_CATALOG_REPO = "savioursho/boj-stat-search-python"
+DEFAULT_CATALOG_REF = "main"
+DEFAULT_METADATA_DIR = "metadata"
+
+
+class CatalogError(RuntimeError):
+    """Base exception for local catalog loading failures."""
+
+
+class CatalogFetchError(CatalogError):
+    """Raised when catalog download fails."""
+
+
+class CatalogCacheError(CatalogError):
+    """Raised when catalog cache read/write fails."""
+
+
+def load_catalog_db(
+    db: str,
+    *,
+    cache_ttl_seconds: int = DEFAULT_CACHE_TTL_SECONDS,
+    cache_dir: str | Path | None = None,
+    repo: str = DEFAULT_CATALOG_REPO,
+    ref: str = DEFAULT_CATALOG_REF,
+    metadata_dir: str = DEFAULT_METADATA_DIR,
+    client: httpx.Client | None = None,
+) -> pa.Table:
+    """Load one DB catalog table, fetching from GitHub raw when cache is stale."""
+    if cache_ttl_seconds < 0:
+        raise ValueError("cache_ttl_seconds must be >= 0")
+
+    cache_path = _cache_file_path(db, cache_dir=cache_dir)
+    should_refresh = _is_stale(cache_path, ttl_seconds=cache_ttl_seconds)
+
+    owns_client = client is None
+    http_client = client if client is not None else httpx.Client()
+
+    try:
+        if should_refresh:
+            _refresh_cache(
+                db=db,
+                cache_path=cache_path,
+                repo=repo,
+                ref=ref,
+                metadata_dir=metadata_dir,
+                client=http_client,
+            )
+            return _read_catalog_table(cache_path, db=db)
+
+        try:
+            return _read_catalog_table(cache_path, db=db)
+        except CatalogCacheError:
+            # Recover from a corrupted but "fresh" file by forcing one re-download.
+            _refresh_cache(
+                db=db,
+                cache_path=cache_path,
+                repo=repo,
+                ref=ref,
+                metadata_dir=metadata_dir,
+                client=http_client,
+            )
+            return _read_catalog_table(cache_path, db=db)
+    finally:
+        if owns_client:
+            http_client.close()
+
+
+def load_catalog_all(
+    *,
+    dbs: Sequence[str] | None = None,
+    cache_ttl_seconds: int = DEFAULT_CACHE_TTL_SECONDS,
+    cache_dir: str | Path | None = None,
+    repo: str = DEFAULT_CATALOG_REPO,
+    ref: str = DEFAULT_CATALOG_REF,
+    metadata_dir: str = DEFAULT_METADATA_DIR,
+    client: httpx.Client | None = None,
+) -> pa.Table:
+    """Load and concatenate catalog tables for all (or selected) DBs."""
+    resolved_dbs = _resolve_dbs(dbs)
+    if not resolved_dbs:
+        return pa.table({})
+
+    owns_client = client is None
+    http_client = client if client is not None else httpx.Client()
+
+    try:
+        tables = [
+            load_catalog_db(
+                db,
+                cache_ttl_seconds=cache_ttl_seconds,
+                cache_dir=cache_dir,
+                repo=repo,
+                ref=ref,
+                metadata_dir=metadata_dir,
+                client=http_client,
+            )
+            for db in resolved_dbs
+        ]
+    finally:
+        if owns_client:
+            http_client.close()
+
+    if len(tables) == 1:
+        return tables[0]
+
+    try:
+        return pa.concat_tables(tables, promote_options="default")
+    except Exception as exc:
+        raise CatalogCacheError(
+            f"Failed to concatenate catalog tables for DBs: {', '.join(resolved_dbs)}"
+        ) from exc
+
+
+def _resolve_dbs(dbs: Sequence[str] | None) -> tuple[str, ...]:
+    if dbs is None:
+        return tuple(db_info.name for db_info in list_db())
+
+    # Keep caller-specified order while removing duplicates.
+    return tuple(dict.fromkeys(dbs))
+
+
+def _refresh_cache(
+    *,
+    db: str,
+    cache_path: Path,
+    repo: str,
+    ref: str,
+    metadata_dir: str,
+    client: httpx.Client,
+) -> None:
+    url = _build_raw_url(repo=repo, ref=ref, db=db, metadata_dir=metadata_dir)
+    content = _download_parquet(url, client=client)
+
+    try:
+        _atomic_write_bytes(cache_path, content)
+    except OSError as exc:
+        raise CatalogCacheError(
+            f"Failed to write catalog cache file for {db} at {cache_path}"
+        ) from exc
+
+
+def _read_catalog_table(cache_path: Path, *, db: str) -> pa.Table:
+    try:
+        table = pq.read_table(cache_path)
+    except Exception as exc:
+        raise CatalogCacheError(
+            f"Failed to read catalog cache file for {db} at {cache_path}"
+        ) from exc
+
+    if "db" in table.column_names:
+        return table
+
+    db_column = pa.array([db] * table.num_rows, type=pa.string())
+    return table.append_column("db", db_column)
+
+
+def _download_parquet(url: str, *, client: httpx.Client) -> bytes:
+    try:
+        response = client.get(url)
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise CatalogFetchError(f"Failed to download catalog data from {url}") from exc
+
+    if not response.content:
+        raise CatalogFetchError(f"Catalog response is empty for {url}")
+
+    return response.content
+
+
+def _cache_file_path(db: str, *, cache_dir: str | Path | None) -> Path:
+    return _cache_root(cache_dir) / f"{db}.parquet"
+
+
+def _cache_root(cache_dir: str | Path | None) -> Path:
+    if cache_dir is not None:
+        return Path(cache_dir).expanduser()
+    return _default_cache_root()
+
+
+def _default_cache_root() -> Path:
+    if os.name == "nt":
+        base = Path(os.environ.get("LOCALAPPDATA") or (Path.home() / "AppData/Local"))
+    elif sys.platform == "darwin":
+        base = Path.home() / "Library/Caches"
+    else:
+        base = Path(os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache"))
+    return base / "boj-stat-search" / "catalog"
+
+
+def _is_stale(path: Path, *, ttl_seconds: int, now: float | None = None) -> bool:
+    if not path.exists():
+        return True
+    if ttl_seconds == 0:
+        return True
+    now_time = now if now is not None else time.time()
+    return now_time - path.stat().st_mtime > ttl_seconds
+
+
+def _build_raw_url(*, repo: str, ref: str, db: str, metadata_dir: str) -> str:
+    metadata_path = metadata_dir.strip("/")
+    encoded_db = quote(db, safe="")
+    return (
+        f"https://raw.githubusercontent.com/{repo}/{ref}/"
+        f"{metadata_path}/{encoded_db}.parquet"
+    )
+
+
+def _atomic_write_bytes(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path: Path | None = None
+
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            temp_file.write(content)
+
+        if temp_path is None:
+            raise RuntimeError("Failed to create temporary catalog cache file")
+
+        temp_path.replace(path)
+    except Exception:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
+        raise

--- a/tests/test_catalog_loader.py
+++ b/tests/test_catalog_loader.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import Mock
+
+import httpx
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from boj_stat_search.catalog.loader import (
+    CatalogCacheError,
+    CatalogFetchError,
+    load_catalog_all,
+    load_catalog_db,
+)
+from boj_stat_search.models import DbInfo
+
+
+def _parquet_bytes(rows: list[dict[str, str]]) -> bytes:
+    table = pa.Table.from_pylist(rows)
+    sink = pa.BufferOutputStream()
+    pq.write_table(table, sink)
+    return sink.getvalue().to_pybytes()
+
+
+def _write_cached_parquet(path: Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    table = pa.Table.from_pylist(rows)
+    pq.write_table(table, path)
+
+
+def _mock_response(content: bytes) -> Mock:
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.content = content
+    return response
+
+
+def test_load_catalog_db_downloads_and_caches_on_first_use(tmp_path: Path) -> None:
+    client = Mock(spec=httpx.Client)
+    client.get.return_value = _mock_response(_parquet_bytes([{"series_code": "A"}]))
+
+    table = load_catalog_db("FM01", cache_dir=tmp_path, client=client)
+
+    assert (tmp_path / "FM01.parquet").exists()
+    assert table.column("series_code").to_pylist() == ["A"]
+    assert table.column("db").to_pylist() == ["FM01"]
+    client.get.assert_called_once_with(
+        "https://raw.githubusercontent.com/savioursho/boj-stat-search-python/main/metadata/FM01.parquet"
+    )
+
+
+def test_load_catalog_db_uses_fresh_cache_without_network(tmp_path: Path) -> None:
+    cache_path = tmp_path / "FM01.parquet"
+    _write_cached_parquet(cache_path, [{"series_code": "CACHED"}])
+
+    client = Mock(spec=httpx.Client)
+    table = load_catalog_db(
+        "FM01",
+        cache_ttl_seconds=3600,
+        cache_dir=tmp_path,
+        client=client,
+    )
+
+    assert table.column("series_code").to_pylist() == ["CACHED"]
+    client.get.assert_not_called()
+
+
+def test_load_catalog_db_refetches_when_cache_is_stale(tmp_path: Path) -> None:
+    cache_path = tmp_path / "FM01.parquet"
+    _write_cached_parquet(cache_path, [{"series_code": "OLD"}])
+
+    old_time = time.time() - 7200
+    os.utime(cache_path, (old_time, old_time))
+
+    client = Mock(spec=httpx.Client)
+    client.get.return_value = _mock_response(_parquet_bytes([{"series_code": "NEW"}]))
+
+    table = load_catalog_db(
+        "FM01",
+        cache_ttl_seconds=60,
+        cache_dir=tmp_path,
+        client=client,
+    )
+
+    assert table.column("series_code").to_pylist() == ["NEW"]
+    assert pq.read_table(cache_path).column("series_code").to_pylist() == ["NEW"]
+    client.get.assert_called_once()
+
+
+def test_load_catalog_db_recovers_from_corrupted_fresh_cache(tmp_path: Path) -> None:
+    cache_path = tmp_path / "FM01.parquet"
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_bytes(b"not-parquet")
+
+    client = Mock(spec=httpx.Client)
+    client.get.return_value = _mock_response(
+        _parquet_bytes([{"series_code": "RECOVERED"}])
+    )
+
+    table = load_catalog_db(
+        "FM01",
+        cache_ttl_seconds=3600,
+        cache_dir=tmp_path,
+        client=client,
+    )
+
+    assert table.column("series_code").to_pylist() == ["RECOVERED"]
+    client.get.assert_called_once()
+
+
+def test_load_catalog_db_raises_fetch_error_on_http_failure(tmp_path: Path) -> None:
+    client = Mock(spec=httpx.Client)
+    client.get.side_effect = httpx.ConnectError("boom")
+
+    with pytest.raises(CatalogFetchError):
+        load_catalog_db("FM01", cache_dir=tmp_path, client=client)
+
+
+def test_load_catalog_db_raises_cache_error_on_invalid_parquet(tmp_path: Path) -> None:
+    client = Mock(spec=httpx.Client)
+    client.get.return_value = _mock_response(b"definitely-not-parquet")
+
+    with pytest.raises(CatalogCacheError):
+        load_catalog_db("FM01", cache_dir=tmp_path, client=client)
+
+
+def test_load_catalog_all_merges_requested_dbs(tmp_path: Path) -> None:
+    client = Mock(spec=httpx.Client)
+    client.get.side_effect = [
+        _mock_response(_parquet_bytes([{"series_code": "FM_CODE"}])),
+        _mock_response(_parquet_bytes([{"series_code": "BP_CODE"}])),
+    ]
+
+    table = load_catalog_all(
+        dbs=["FM01", "BP01"],
+        cache_dir=tmp_path,
+        client=client,
+    )
+
+    assert table.num_rows == 2
+    assert table.column("series_code").to_pylist() == ["FM_CODE", "BP_CODE"]
+    assert table.column("db").to_pylist() == ["FM01", "BP01"]
+    assert client.get.call_count == 2
+
+
+def test_load_catalog_all_defaults_to_list_db(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "boj_stat_search.catalog.loader.list_db",
+        lambda: (
+            DbInfo(name="FM01", desc="desc", category="cat"),
+            DbInfo(name="BP01", desc="desc", category="cat"),
+        ),
+    )
+
+    client = Mock(spec=httpx.Client)
+    client.get.side_effect = [
+        _mock_response(_parquet_bytes([{"series_code": "FM_CODE"}])),
+        _mock_response(_parquet_bytes([{"series_code": "BP_CODE"}])),
+    ]
+
+    table = load_catalog_all(cache_dir=tmp_path, client=client)
+
+    assert table.column("db").to_pylist() == ["FM01", "BP01"]
+    assert client.get.call_count == 2
+
+
+def test_load_catalog_db_respects_custom_ttl_zero(tmp_path: Path) -> None:
+    cache_path = tmp_path / "FM01.parquet"
+    _write_cached_parquet(cache_path, [{"series_code": "OLD"}])
+
+    client = Mock(spec=httpx.Client)
+    client.get.return_value = _mock_response(_parquet_bytes([{"series_code": "NEW"}]))
+
+    table = load_catalog_db(
+        "FM01",
+        cache_ttl_seconds=0,
+        cache_dir=tmp_path,
+        client=client,
+    )
+
+    assert table.column("series_code").to_pylist() == ["NEW"]
+    client.get.assert_called_once()
+
+
+def test_load_catalog_db_does_not_close_external_client(tmp_path: Path) -> None:
+    client = Mock(spec=httpx.Client)
+    client.get.return_value = _mock_response(_parquet_bytes([{"series_code": "A"}]))
+
+    load_catalog_db("FM01", cache_dir=tmp_path, client=client)
+
+    client.close.assert_not_called()
+
+
+def test_load_catalog_all_reuses_one_internal_client(
+    tmp_path: Path, monkeypatch
+) -> None:
+    internal_client = Mock(spec=httpx.Client)
+    internal_client.get.side_effect = [
+        _mock_response(_parquet_bytes([{"series_code": "FM_CODE"}])),
+        _mock_response(_parquet_bytes([{"series_code": "BP_CODE"}])),
+    ]
+    factory = Mock(return_value=internal_client)
+    monkeypatch.setattr("boj_stat_search.catalog.loader.httpx.Client", factory)
+
+    load_catalog_all(dbs=["FM01", "BP01"], cache_dir=tmp_path)
+
+    factory.assert_called_once()
+    assert internal_client.get.call_count == 2
+    internal_client.close.assert_called_once()
+
+
+def test_load_catalog_all_does_not_close_external_client(tmp_path: Path) -> None:
+    client = Mock(spec=httpx.Client)
+    client.get.side_effect = [
+        _mock_response(_parquet_bytes([{"series_code": "FM_CODE"}])),
+        _mock_response(_parquet_bytes([{"series_code": "BP_CODE"}])),
+    ]
+
+    load_catalog_all(dbs=["FM01", "BP01"], cache_dir=tmp_path, client=client)
+
+    client.close.assert_not_called()

--- a/tests/test_metadata_export.py
+++ b/tests/test_metadata_export.py
@@ -237,7 +237,9 @@ def test_generate_metadata_parquet_files_continues_on_failures_and_reports_them(
     )
 
     output_dir = tmp_path / "metadata"
-    report = generate_metadata_parquet_files(output_dir=output_dir, dbs=["FM01", "BP01"])
+    report = generate_metadata_parquet_files(
+        output_dir=output_dir, dbs=["FM01", "BP01"]
+    )
 
     assert report.is_success is False
     assert report.succeeded_dbs == ("FM01",)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -10,8 +10,13 @@ from boj_stat_search.api import (
     get_metadata_raw as api_get_metadata_raw,
 )
 from boj_stat_search.catalog import (
+    CatalogCacheError as CatalogCatalogCacheError,
+    CatalogError as CatalogCatalogError,
+    CatalogFetchError as CatalogCatalogFetchError,
     MetadataExportReport as CatalogMetadataExportReport,
     generate_metadata_parquet_files as catalog_generate_metadata_parquet_files,
+    load_catalog_all as catalog_load_catalog_all,
+    load_catalog_db as catalog_load_catalog_db,
 )
 from boj_stat_search.core import Frequency as CoreFrequency
 from boj_stat_search.core import Layer as CoreLayer
@@ -36,6 +41,8 @@ def test_top_level_re_exports_functional_api():
     assert (
         bss.generate_metadata_parquet_files is catalog_generate_metadata_parquet_files
     )
+    assert bss.load_catalog_db is catalog_load_catalog_db
+    assert bss.load_catalog_all is catalog_load_catalog_all
     assert bss.show_layers is display_show_layers
 
 
@@ -44,6 +51,9 @@ def test_top_level_re_exports_key_types_and_models():
     assert bss.Layer is CoreLayer
     assert bss.Period is CorePeriod
     assert bss.MetadataExportReport is CatalogMetadataExportReport
+    assert bss.CatalogError is CatalogCatalogError
+    assert bss.CatalogFetchError is CatalogCatalogFetchError
+    assert bss.CatalogCacheError is CatalogCatalogCacheError
     assert bss.BaseResponse is ModelsBaseResponse
     assert bss.MetadataEntry is ModelsMetadataEntry
     assert bss.MetadataResponse is ModelsMetadataResponse
@@ -61,10 +71,15 @@ def test_top_level_has_expected_public_symbols():
         "get_data_layer_raw",
         "get_data_layer",
         "generate_metadata_parquet_files",
+        "load_catalog_db",
+        "load_catalog_all",
         "Frequency",
         "Layer",
         "Period",
         "MetadataExportReport",
+        "CatalogError",
+        "CatalogFetchError",
+        "CatalogCacheError",
         "BaseResponse",
         "DbInfo",
         "MetadataEntry",


### PR DESCRIPTION
## Summary
- add `catalog.loader` with `load_catalog_db` and `load_catalog_all`
- implement local cache with configurable TTL and stale re-fetch from GitHub raw
- add explicit catalog fetch/cache exceptions and atomic cache writes
- export loader APIs from package top-level and catalog namespace
- add tests for cache hit/miss/stale/error/client lifecycle behavior

## Validation
- `UV_CACHE_DIR=/tmp/.uv-cache uv run ruff format`
- `UV_CACHE_DIR=/tmp/.uv-cache uv run ruff check src tests`
- `UV_CACHE_DIR=/tmp/.uv-cache uv run ty check`
- `UV_CACHE_DIR=/tmp/.uv-cache uv run pytest -q`