### PR TITLE
Add search_series for local catalog discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ fm01_catalog = load_catalog_db("FM01")
 print(fm01_catalog.num_rows)
 ```
 
+```python
+from boj_stat_search import search_series
+
+# Search across local catalog metadata (cached automatically)
+results = search_series("exchange rate", db="FM01")
+print(results[0].series_code if results else "no match")
+```
+
 ## Documentation
 
 - [User Guide](./docs/user_guide/README.md)

--- a/docs/user_guide/README.md
+++ b/docs/user_guide/README.md
@@ -5,7 +5,7 @@ This guide explains how to use `boj_stat_search` for common tasks.
 The package can be used in three ways:
 
 - **CLI** — the `boj-stat-search` command lets you query data directly from the terminal. JSON output is designed for piping to `jq` and other tools.
-- **Functional API** — top-level functions (`get_metadata`, `get_data_code`, `get_data_layer`, `generate_metadata_parquet_files`, `load_catalog_db`, `load_catalog_all`). Simple and composable; no built-in throttling, so callers must manage delays manually for batch use.
+- **Functional API** — top-level functions (`get_metadata`, `get_data_code`, `get_data_layer`, `generate_metadata_parquet_files`, `load_catalog_db`, `load_catalog_all`, `search_series`). Simple and composable; no built-in throttling, so callers must manage delays manually for batch use.
 - **`BojClient`** — a stateful client that wraps the functional API. Reuses a single HTTP connection and enforces a configurable minimum delay between requests (default 1 s). Preferred for batch workflows.
 
 ## Who This Is For
@@ -30,6 +30,7 @@ The package can be used in three ways:
   - `generate_metadata_parquet_files`
   - `load_catalog_db`
   - `load_catalog_all`
+  - `search_series`
   - `BojClient` (stateful client with built-in throttling)
   - `show_layers`
   - `list_db`

--- a/docs/user_guide/querying_data.md
+++ b/docs/user_guide/querying_data.md
@@ -19,6 +19,18 @@ response = get_data_code(
 print(response.status, len(response.result_set))
 ```
 
+## Series Discovery with Local Catalog
+
+Use `search_series` to find candidate series codes from locally cached metadata.
+
+```python
+from boj_stat_search import Layer, search_series
+
+results = search_series("exchange rate", db="FM01", layer=Layer(1, "*"))
+for entry in results[:5]:
+    print(entry.db, entry.series_code, entry.name_en)
+```
+
 ## Data by Layer + Frequency
 
 Use `get_data_layer` to query by hierarchy.
@@ -229,6 +241,7 @@ from boj_stat_search import (
     Period,
     get_data_code,
     get_data_layer,
+    search_series,
 )
 ```
 

--- a/src/boj_stat_search/__init__.py
+++ b/src/boj_stat_search/__init__.py
@@ -16,6 +16,7 @@ from boj_stat_search.catalog import (
     generate_metadata_parquet_files,
     load_catalog_all,
     load_catalog_db,
+    search_series,
 )
 from boj_stat_search.core import Frequency, Layer, Period, list_db
 from boj_stat_search.display import show_layers
@@ -25,6 +26,7 @@ from boj_stat_search.models import (
     DbInfo,
     MetadataEntry,
     MetadataResponse,
+    SeriesCatalogEntry,
 )
 
 __all__ = [
@@ -39,6 +41,7 @@ __all__ = [
     "generate_metadata_parquet_files",
     "load_catalog_db",
     "load_catalog_all",
+    "search_series",
     "Frequency",
     "Layer",
     "Period",
@@ -49,6 +52,7 @@ __all__ = [
     "BaseResponse",
     "DbInfo",
     "MetadataEntry",
+    "SeriesCatalogEntry",
     "MetadataResponse",
     "DataResponse",
     "list_db",

--- a/src/boj_stat_search/catalog/__init__.py
+++ b/src/boj_stat_search/catalog/__init__.py
@@ -12,6 +12,7 @@ from boj_stat_search.catalog.loader import (
     load_catalog_all,
     load_catalog_db,
 )
+from boj_stat_search.catalog.search import search_series
 
 __all__ = [
     "METADATA_PARQUET_COLUMNS",
@@ -24,4 +25,5 @@ __all__ = [
     "CatalogCacheError",
     "load_catalog_db",
     "load_catalog_all",
+    "search_series",
 ]

--- a/src/boj_stat_search/catalog/search.py
+++ b/src/boj_stat_search/catalog/search.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pyarrow as pa
+
+from boj_stat_search.catalog.loader import (
+    DEFAULT_CACHE_TTL_SECONDS,
+    DEFAULT_CATALOG_REF,
+    DEFAULT_CATALOG_REPO,
+    DEFAULT_METADATA_DIR,
+    CatalogError,
+    load_catalog_all,
+    load_catalog_db,
+)
+from boj_stat_search.core import Layer, list_db
+from boj_stat_search.core.validator import coerce_layer
+from boj_stat_search.models import SeriesCatalogEntry
+
+_SEARCH_FIELDS: tuple[str, ...] = ("name_j", "name_en", "category_j", "category_en")
+_REQUIRED_COLUMNS: tuple[str, ...] = (
+    "db",
+    "series_code",
+    "name_j",
+    "name_en",
+    "unit_j",
+    "unit_en",
+    "frequency",
+    "category_j",
+    "category_en",
+    "layer1",
+    "layer2",
+    "layer3",
+    "layer4",
+    "layer5",
+    "start_of_time_series",
+    "end_of_time_series",
+    "last_update",
+    "notes_j",
+    "notes_en",
+)
+
+
+def search_series(
+    keyword: str,
+    *,
+    db: str | None = None,
+    dbs: Sequence[str] | None = None,
+    layer: Layer | str | None = None,
+    cache_ttl_seconds: int = DEFAULT_CACHE_TTL_SECONDS,
+    cache_dir: str | Path | None = None,
+    repo: str = DEFAULT_CATALOG_REPO,
+    ref: str = DEFAULT_CATALOG_REF,
+    metadata_dir: str = DEFAULT_METADATA_DIR,
+    client: httpx.Client | None = None,
+) -> tuple[SeriesCatalogEntry, ...]:
+    """Search local metadata catalog entries by keyword."""
+    normalized_keyword = _normalize_keyword(keyword)
+    known_dbs = {db_info.name for db_info in list_db()}
+    resolved_dbs = _resolve_dbs(db=db, dbs=dbs, known_dbs=known_dbs)
+    layer_parts = _coerce_and_validate_layer(layer)
+
+    if resolved_dbs is not None and len(resolved_dbs) == 0:
+        return ()
+
+    if resolved_dbs is None:
+        table = load_catalog_all(
+            cache_ttl_seconds=cache_ttl_seconds,
+            cache_dir=cache_dir,
+            repo=repo,
+            ref=ref,
+            metadata_dir=metadata_dir,
+            client=client,
+        )
+    elif len(resolved_dbs) == 1:
+        table = load_catalog_db(
+            resolved_dbs[0],
+            cache_ttl_seconds=cache_ttl_seconds,
+            cache_dir=cache_dir,
+            repo=repo,
+            ref=ref,
+            metadata_dir=metadata_dir,
+            client=client,
+        )
+    else:
+        table = load_catalog_all(
+            dbs=resolved_dbs,
+            cache_ttl_seconds=cache_ttl_seconds,
+            cache_dir=cache_dir,
+            repo=repo,
+            ref=ref,
+            metadata_dir=metadata_dir,
+            client=client,
+        )
+
+    entries = _table_to_entries(table)
+
+    return tuple(
+        entry
+        for entry in entries
+        if _row_matches_layer(entry, layer_parts)
+        and _row_matches_keyword(entry, normalized_keyword)
+    )
+
+
+def _normalize_keyword(keyword: str) -> str:
+    if not isinstance(keyword, str):
+        raise ValueError("keyword: must be a string")
+    normalized = keyword.strip()
+    if not normalized:
+        raise ValueError("keyword: must not be empty")
+    return normalized.casefold()
+
+
+def _resolve_dbs(
+    *,
+    db: str | None,
+    dbs: Sequence[str] | None,
+    known_dbs: set[str],
+) -> tuple[str, ...] | None:
+    if db is not None and dbs is not None:
+        raise ValueError("db and dbs cannot both be provided")
+
+    if db is not None:
+        if db not in known_dbs:
+            raise ValueError("db: must be one of known DB names in list_db()")
+        return (db,)
+
+    if dbs is None:
+        return None
+
+    resolved_dbs: list[str] = []
+    seen: set[str] = set()
+    for name in dbs:
+        if not isinstance(name, str):
+            raise ValueError("dbs: each DB name must be a string")
+        if name not in known_dbs:
+            raise ValueError("dbs: each DB must be one of known DB names in list_db()")
+        if name in seen:
+            continue
+        seen.add(name)
+        resolved_dbs.append(name)
+
+    return tuple(resolved_dbs)
+
+
+def _coerce_and_validate_layer(layer: Layer | str | None) -> tuple[str, ...] | None:
+    if layer is None:
+        return None
+
+    normalized = coerce_layer(layer)
+    if not isinstance(normalized, str):
+        raise ValueError("layer: must be a string or Layer")
+    if normalized == "":
+        raise ValueError("layer: must not be empty")
+
+    parts = [part.strip() for part in normalized.split(",")]
+    if len(parts) < 1 or len(parts) > 5:
+        raise ValueError("layer: must have between 1 and 5 comma-separated values")
+    if any(part == "" for part in parts):
+        raise ValueError("layer: must not contain empty layer values")
+
+    for part in parts:
+        if part != "*" and not part.isdigit():
+            raise ValueError("layer: each layer must be '*' or digits only")
+
+    return tuple(parts)
+
+
+def _row_matches_layer(
+    row: SeriesCatalogEntry, layer_parts: tuple[str, ...] | None
+) -> bool:
+    if layer_parts is None:
+        return True
+
+    row_layers = (
+        str(row.layer1),
+        str(row.layer2),
+        str(row.layer3),
+        str(row.layer4),
+        str(row.layer5),
+    )
+
+    for index, expected in enumerate(layer_parts):
+        if expected == "*":
+            continue
+        if row_layers[index] != expected:
+            return False
+
+    return True
+
+
+def _row_matches_keyword(row: SeriesCatalogEntry, normalized_keyword: str) -> bool:
+    for field in _SEARCH_FIELDS:
+        value = getattr(row, field)
+        if normalized_keyword in value.casefold():
+            return True
+    return False
+
+
+def _table_to_entries(table: pa.Table) -> tuple[SeriesCatalogEntry, ...]:
+    _ensure_required_columns(table.column_names)
+
+    entries: list[SeriesCatalogEntry] = []
+    for row in table.to_pylist():
+        entries.append(_row_to_entry(row))
+    return tuple(entries)
+
+
+def _ensure_required_columns(column_names: list[str]) -> None:
+    missing = [column for column in _REQUIRED_COLUMNS if column not in column_names]
+    if missing:
+        raise CatalogError(
+            "Catalog table is missing required columns: " + ", ".join(missing)
+        )
+
+
+def _row_to_entry(row: dict[str, Any]) -> SeriesCatalogEntry:
+    try:
+        return SeriesCatalogEntry(
+            db=_required_str(row, "db"),
+            series_code=_required_str(row, "series_code"),
+            name_j=_required_str(row, "name_j"),
+            name_en=_required_str(row, "name_en"),
+            unit_j=_required_str(row, "unit_j"),
+            unit_en=_required_str(row, "unit_en"),
+            frequency=_required_str(row, "frequency"),
+            category_j=_required_str(row, "category_j"),
+            category_en=_required_str(row, "category_en"),
+            layer1=_required_int(row, "layer1"),
+            layer2=_required_int(row, "layer2"),
+            layer3=_required_int(row, "layer3"),
+            layer4=_required_int(row, "layer4"),
+            layer5=_required_int(row, "layer5"),
+            start_of_time_series=_required_str(row, "start_of_time_series"),
+            end_of_time_series=_required_str(row, "end_of_time_series"),
+            last_update=_required_str(row, "last_update"),
+            notes_j=_required_str(row, "notes_j"),
+            notes_en=_required_str(row, "notes_en"),
+        )
+    except ValueError as exc:
+        raise CatalogError("Catalog row contains invalid values") from exc
+
+
+def _required_str(row: dict[str, Any], field: str) -> str:
+    value = row[field]
+    if not isinstance(value, str):
+        raise ValueError(f"{field}: must be a string")
+    return value
+
+
+def _required_int(row: dict[str, Any], field: str) -> int:
+    value = row[field]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field}: must be an integer")
+    return value

--- a/src/boj_stat_search/models/__init__.py
+++ b/src/boj_stat_search/models/__init__.py
@@ -32,6 +32,29 @@ class MetadataEntry:
 
 
 @dataclass(frozen=True)
+class SeriesCatalogEntry:
+    db: str
+    series_code: str
+    name_j: str
+    name_en: str
+    unit_j: str
+    unit_en: str
+    frequency: str
+    category_j: str
+    category_en: str
+    layer1: int
+    layer2: int
+    layer3: int
+    layer4: int
+    layer5: int
+    start_of_time_series: str
+    end_of_time_series: str
+    last_update: str
+    notes_j: str
+    notes_en: str
+
+
+@dataclass(frozen=True)
 class BaseResponse:
     status: int
     message_id: str

--- a/tests/test_catalog_search.py
+++ b/tests/test_catalog_search.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import httpx
+import pyarrow as pa
+import pytest
+
+from boj_stat_search.catalog import CatalogError, search_series
+from boj_stat_search.core import Layer
+from boj_stat_search.models import SeriesCatalogEntry
+
+
+def _make_row(
+    *,
+    db: str,
+    series_code: str,
+    name_j: str,
+    name_en: str,
+    category_j: str = "カテゴリ",
+    category_en: str = "Category",
+    layer1: int = 1,
+    layer2: int = 0,
+    layer3: int = 0,
+    layer4: int = 0,
+    layer5: int = 0,
+) -> dict[str, str | int]:
+    return {
+        "db": db,
+        "series_code": series_code,
+        "name_j": name_j,
+        "name_en": name_en,
+        "unit_j": "unit-j",
+        "unit_en": "unit-en",
+        "frequency": "M",
+        "category_j": category_j,
+        "category_en": category_en,
+        "layer1": layer1,
+        "layer2": layer2,
+        "layer3": layer3,
+        "layer4": layer4,
+        "layer5": layer5,
+        "start_of_time_series": "199901",
+        "end_of_time_series": "202601",
+        "last_update": "20260222",
+        "notes_j": "",
+        "notes_en": "",
+    }
+
+
+def _table(rows: list[dict[str, str | int]]) -> pa.Table:
+    return pa.Table.from_pylist(rows)
+
+
+def test_search_series_matches_japanese_keyword(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "boj_stat_search.catalog.search.load_catalog_all",
+        lambda **_: _table(
+            [
+                _make_row(
+                    db="FM01",
+                    series_code="FM01'A",
+                    name_j="対米ドル為替レート",
+                    name_en="USD/JPY",
+                ),
+                _make_row(
+                    db="BP01",
+                    series_code="BP01'B",
+                    name_j="マネーストック",
+                    name_en="Money Stock",
+                ),
+            ]
+        ),
+    )
+
+    results = search_series("為替")
+
+    assert tuple(entry.series_code for entry in results) == ("FM01'A",)
+    assert isinstance(results[0], SeriesCatalogEntry)
+
+
+def test_search_series_matches_english_keyword_case_insensitive(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "boj_stat_search.catalog.search.load_catalog_all",
+        lambda **_: _table(
+            [
+                _make_row(
+                    db="FM01",
+                    series_code="FM01'A",
+                    name_j="対米ドル為替レート",
+                    name_en="Exchange Rate",
+                ),
+                _make_row(
+                    db="FM01",
+                    series_code="FM01'B",
+                    name_j="無担保コール",
+                    name_en="Call Rate",
+                ),
+            ]
+        ),
+    )
+
+    results = search_series("eXcHaNgE")
+
+    assert tuple(entry.series_code for entry in results) == ("FM01'A",)
+
+
+def test_search_series_matches_category_fields(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "boj_stat_search.catalog.search.load_catalog_all",
+        lambda **_: _table(
+            [
+                _make_row(
+                    db="FM01",
+                    series_code="FM01'A",
+                    name_j="無担保コール",
+                    name_en="Call Rate",
+                    category_j="金融市場",
+                    category_en="Financial Markets",
+                ),
+                _make_row(
+                    db="BP01",
+                    series_code="BP01'B",
+                    name_j="マネーストック",
+                    name_en="Money Stock",
+                    category_j="通貨",
+                    category_en="Money",
+                ),
+            ]
+        ),
+    )
+
+    results = search_series("financial")
+
+    assert tuple(entry.series_code for entry in results) == ("FM01'A",)
+
+
+def test_search_series_with_db_uses_load_catalog_db(monkeypatch) -> None:
+    load_db = Mock(
+        return_value=_table(
+            [
+                _make_row(
+                    db="FM01",
+                    series_code="FM01'A",
+                    name_j="無担保コール",
+                    name_en="Call Rate",
+                )
+            ]
+        )
+    )
+    load_all = Mock()
+    monkeypatch.setattr("boj_stat_search.catalog.search.load_catalog_db", load_db)
+    monkeypatch.setattr("boj_stat_search.catalog.search.load_catalog_all", load_all)
+
+    results = search_series("call", db="FM01")
+
+    assert tuple(entry.series_code for entry in results) == ("FM01'A",)
+    load_db.assert_called_once()
+    load_all.assert_not_called()
+
+
+def test_search_series_with_dbs_uses_load_catalog_all(monkeypatch) -> None:
+    load_all = Mock(
+        return_value=_table(
+            [
+                _make_row(
+                    db="FM01",
+                    series_code="FM01'A",
+                    name_j="無担保コール",
+                    name_en="Call Rate",
+                ),
+                _make_row(
+                    db="BP01",
+                    series_code="BP01'B",
+                    name_j="マネーストック",
+                    name_en="Money Stock",
+                ),
+            ]
+        )
+    )
+    load_db = Mock()
+    monkeypatch.setattr("boj_stat_search.catalog.search.load_catalog_all", load_all)
+    monkeypatch.setattr("boj_stat_search.catalog.search.load_catalog_db", load_db)
+
+    results = search_series("rate", dbs=["FM01", "BP01", "FM01"])
+
+    assert tuple(entry.series_code for entry in results) == ("FM01'A",)
+    load_all.assert_called_once()
+    assert load_all.call_args.kwargs["dbs"] == ("FM01", "BP01")
+    load_db.assert_not_called()
+
+
+def test_search_series_rejects_db_and_dbs_together() -> None:
+    with pytest.raises(ValueError, match="cannot both be provided"):
+        search_series("rate", db="FM01", dbs=["FM01"])
+
+
+def test_search_series_returns_empty_for_empty_dbs(monkeypatch) -> None:
+    load_all = Mock()
+    load_db = Mock()
+    monkeypatch.setattr("boj_stat_search.catalog.search.load_catalog_all", load_all)
+    monkeypatch.setattr("boj_stat_search.catalog.search.load_catalog_db", load_db)
+
+    results = search_series("rate", dbs=[])
+
+    assert results == ()
+    load_all.assert_not_called()
+    load_db.assert_not_called()
+
+
+def test_search_series_rejects_unknown_db() -> None:
+    with pytest.raises(ValueError, match="list_db"):
+        search_series("rate", db="UNKNOWN")
+
+
+def test_search_series_filters_by_layer_prefix_and_wildcard(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "boj_stat_search.catalog.search.load_catalog_all",
+        lambda **_: _table(
+            [
+                _make_row(
+                    db="FM01",
+                    series_code="FM01'A",
+                    name_j="A",
+                    name_en="Rate A",
+                    layer1=1,
+                    layer2=2,
+                    layer3=3,
+                ),
+                _make_row(
+                    db="FM01",
+                    series_code="FM01'B",
+                    name_j="B",
+                    name_en="Rate B",
+                    layer1=1,
+                    layer2=9,
+                    layer3=3,
+                ),
+                _make_row(
+                    db="FM01",
+                    series_code="FM01'C",
+                    name_j="C",
+                    name_en="Rate C",
+                    layer1=2,
+                    layer2=2,
+                    layer3=3,
+                ),
+            ]
+        ),
+    )
+
+    results = search_series("rate", layer="1,*,3")
+
+    assert tuple(entry.series_code for entry in results) == ("FM01'A", "FM01'B")
+
+
+def test_search_series_accepts_layer_object(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "boj_stat_search.catalog.search.load_catalog_all",
+        lambda **_: _table(
+            [
+                _make_row(
+                    db="FM01",
+                    series_code="FM01'A",
+                    name_j="A",
+                    name_en="Rate A",
+                    layer1=1,
+                    layer2=2,
+                    layer3=3,
+                ),
+                _make_row(
+                    db="FM01",
+                    series_code="FM01'B",
+                    name_j="B",
+                    name_en="Rate B",
+                    layer1=1,
+                    layer2=2,
+                    layer3=4,
+                ),
+            ]
+        ),
+    )
+
+    results = search_series("rate", layer=Layer(1, "*", 3))
+
+    assert tuple(entry.series_code for entry in results) == ("FM01'A",)
+
+
+def test_search_series_rejects_invalid_layer() -> None:
+    with pytest.raises(ValueError, match="digits only"):
+        search_series("rate", layer="1,a")
+
+
+def test_search_series_rejects_empty_keyword() -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        search_series("   ")
+
+
+def test_search_series_forwards_cache_and_client_options(monkeypatch) -> None:
+    load_db = Mock(
+        return_value=_table(
+            [
+                _make_row(
+                    db="FM01",
+                    series_code="FM01'A",
+                    name_j="無担保コール",
+                    name_en="Call Rate",
+                )
+            ]
+        )
+    )
+    monkeypatch.setattr("boj_stat_search.catalog.search.load_catalog_db", load_db)
+
+    client = Mock(spec=httpx.Client)
+    cache_dir = Path("/tmp/catalog-cache")
+    search_series(
+        "call",
+        db="FM01",
+        cache_ttl_seconds=60,
+        cache_dir=cache_dir,
+        repo="owner/repo",
+        ref="develop",
+        metadata_dir="metadata",
+        client=client,
+    )
+
+    load_db.assert_called_once_with(
+        "FM01",
+        cache_ttl_seconds=60,
+        cache_dir=cache_dir,
+        repo="owner/repo",
+        ref="develop",
+        metadata_dir="metadata",
+        client=client,
+    )
+
+
+def test_search_series_raises_catalog_error_when_columns_missing(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "boj_stat_search.catalog.search.load_catalog_all",
+        lambda **_: pa.table({"series_code": ["FM01'A"]}),
+    )
+
+    with pytest.raises(CatalogError, match="missing required columns"):
+        search_series("fm01")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -17,6 +17,7 @@ from boj_stat_search.catalog import (
     generate_metadata_parquet_files as catalog_generate_metadata_parquet_files,
     load_catalog_all as catalog_load_catalog_all,
     load_catalog_db as catalog_load_catalog_db,
+    search_series as catalog_search_series,
 )
 from boj_stat_search.core import Frequency as CoreFrequency
 from boj_stat_search.core import Layer as CoreLayer
@@ -27,6 +28,7 @@ from boj_stat_search.models import (
     DataResponse as ModelsDataResponse,
     MetadataEntry as ModelsMetadataEntry,
     MetadataResponse as ModelsMetadataResponse,
+    SeriesCatalogEntry as ModelsSeriesCatalogEntry,
 )
 
 
@@ -43,6 +45,7 @@ def test_top_level_re_exports_functional_api():
     )
     assert bss.load_catalog_db is catalog_load_catalog_db
     assert bss.load_catalog_all is catalog_load_catalog_all
+    assert bss.search_series is catalog_search_series
     assert bss.show_layers is display_show_layers
 
 
@@ -56,6 +59,7 @@ def test_top_level_re_exports_key_types_and_models():
     assert bss.CatalogCacheError is CatalogCatalogCacheError
     assert bss.BaseResponse is ModelsBaseResponse
     assert bss.MetadataEntry is ModelsMetadataEntry
+    assert bss.SeriesCatalogEntry is ModelsSeriesCatalogEntry
     assert bss.MetadataResponse is ModelsMetadataResponse
     assert bss.DataResponse is ModelsDataResponse
 
@@ -73,6 +77,7 @@ def test_top_level_has_expected_public_symbols():
         "generate_metadata_parquet_files",
         "load_catalog_db",
         "load_catalog_all",
+        "search_series",
         "Frequency",
         "Layer",
         "Period",
@@ -83,6 +88,7 @@ def test_top_level_has_expected_public_symbols():
         "BaseResponse",
         "DbInfo",
         "MetadataEntry",
+        "SeriesCatalogEntry",
         "MetadataResponse",
         "DataResponse",
         "list_db",


### PR DESCRIPTION
## Summary
- add `search_series()` for local catalog keyword search
- add `SeriesCatalogEntry` typed result model
- support optional `db`/`dbs` filter and `layer` filter with `get_data_layer`-style path semantics
- keep search matching case-insensitive across `name_j`, `name_en`, `category_j`, and `category_en`
- expose new API at both `boj_stat_search.catalog` and top-level package

## Validation
- `UV_CACHE_DIR=/tmp/.uv-cache uv run ruff format`
- `UV_CACHE_DIR=/tmp/.uv-cache uv run ruff check src tests`
- `UV_CACHE_DIR=/tmp/.uv-cache uv run ty check`
- `UV_CACHE_DIR=/tmp/.uv-cache uv run pytest -q`
