### PR TITLE
Document BOJ metadata licensing determination

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ print(len(series))
 ## Documentation
 
 - [User Guide](./docs/user_guide/README.md)
+- [Metadata Licensing Determination](./docs/development_guide/metadata_licensing.md)
 
 ## Official Resources
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,4 @@
 
 - **[API Manual](./api_manual/)** — Documents the raw Bank of Japan Stat-Search Web API: endpoints, parameters, response shapes, and discrepancies between the official manual and observed behavior.
 - **[User Guide](./user_guide/)** — Explains how to use the `boj_stat_search` Python package: getting started, querying data, pagination, error handling, and layer tree display.
-- **[Development Guide](./development_guide/)** — Covers the branch policy, release process, and versioning strategy for contributors.
+- **[Development Guide](./development_guide/)** — Covers branch policy, release process, versioning strategy, and metadata licensing determination for contributors.

--- a/docs/development_guide/metadata_licensing.md
+++ b/docs/development_guide/metadata_licensing.md
@@ -1,0 +1,46 @@
+# Metadata Licensing Determination
+
+## Scope
+
+This note documents whether this repository can redistribute BOJ Stat-Search
+metadata files (for example `metadata/FM01.parquet`) that are generated from the
+official Metadata API.
+
+## Source Documents Reviewed
+
+- `https://www.stat-search.boj.or.jp/info/api_notice.pdf`
+- `https://www.stat-search.boj.or.jp/info/notice.html`
+
+Reviewed on: **February 22, 2026**
+
+## Determination
+
+**Conditionally permitted.**
+
+Redistribution of metadata is allowed when the following conditions are met:
+
+1. Attribution/source display is included.
+2. Required API credit statement is displayed when publishing a service that
+   uses the API.
+3. No unauthorized modification of source content is performed.
+4. Commercial-purpose reproduction requires prior consultation with BOJ.
+5. API usage must avoid high-frequency access patterns.
+
+## Operational Rules For This Repository
+
+1. Keep attribution in project docs and in `metadata/NOTICE.md`.
+2. Treat generated metadata files as factual copies in a different file format
+   (Parquet), without semantic edits to names/codes/categories/date fields.
+3. If metadata redistribution is tied to commercial use, consult BOJ first
+   (per site notice).
+4. If operating a publicly available service that uses the API, notify
+   `post.rsd17@boj.or.jp` with the requested subject format described in
+   `api_notice.pdf`.
+5. Treat BOJ source-site terms as governing terms for redistributed metadata
+   files.
+
+## Notes
+
+- This is a project compliance record, not legal advice.
+- BOJ may update terms without prior notice; re-check source URLs before each
+  release that changes metadata distribution behavior.

--- a/docs/development_guide/release_process.md
+++ b/docs/development_guide/release_process.md
@@ -89,3 +89,13 @@ This project follows [Semantic Versioning](https://semver.org/):
 - **MAJOR** — incompatible API changes.
 - **MINOR** — new functionality in a backwards-compatible manner.
 - **PATCH** — backwards-compatible bug fixes.
+
+## Metadata Compliance
+
+When metadata files are updated or newly distributed, follow:
+
+- `docs/development_guide/metadata_licensing.md`
+- `metadata/NOTICE.md`
+
+In particular, keep source attribution in place and re-check BOJ terms before
+changing metadata distribution behavior.

--- a/metadata/NOTICE.md
+++ b/metadata/NOTICE.md
@@ -1,0 +1,19 @@
+# Metadata Source and Attribution
+
+The files in this directory are generated from the Bank of Japan
+Time Series Statistical Data Search API metadata endpoints.
+
+Source site:
+- https://www.stat-search.boj.or.jp/
+
+API terms referenced:
+- https://www.stat-search.boj.or.jp/info/api_notice.pdf
+- https://www.stat-search.boj.or.jp/info/notice.html
+
+Required credit statement (from BOJ API notice):
+- "このサービスは、日本銀行時系列統計データ検索サイトの API 機能を使用しています。サービスの内容は日本銀行によって保証されたものではありません。"
+
+Operational note for this repository:
+- Metadata files are distributed with source attribution.
+- For commercial-purpose reproduction, consult BOJ in advance per site notice.
+- BOJ source-site terms apply to metadata files in this directory.


### PR DESCRIPTION
## Summary
- document a licensing determination for metadata redistribution under BOJ terms
- add metadata attribution notice file under metadata/NOTICE.md
- link licensing guidance from docs and README
- add release-process note to re-check BOJ terms for metadata distribution changes

## Source documents reviewed
- https://www.stat-search.boj.or.jp/info/api_notice.pdf
- https://www.stat-search.boj.or.jp/info/notice.html

## Result
- determination: conditionally permitted, with attribution and usage conditions documented

Closes #17