### PR TITLE
Add Code value object for DB'CODE inputs

### DIFF
--- a/src/boj_stat_search/__init__.py
+++ b/src/boj_stat_search/__init__.py
@@ -19,7 +19,7 @@ from boj_stat_search.catalog import (
     load_catalog_db,
     search_series,
 )
-from boj_stat_search.core import Frequency, Layer, Period, list_db
+from boj_stat_search.core import Code, Frequency, Layer, Period, list_db
 from boj_stat_search.display import show_layers
 from boj_stat_search.models import (
     BaseResponse,
@@ -46,6 +46,7 @@ __all__ = [
     "search_series",
     "Frequency",
     "Layer",
+    "Code",
     "Period",
     "MetadataExportReport",
     "CatalogError",

--- a/src/boj_stat_search/api/api_request.py
+++ b/src/boj_stat_search/api/api_request.py
@@ -6,7 +6,7 @@ from boj_stat_search.core.parser import (
     parse_data_code_response,
     parse_metadata_response,
 )
-from boj_stat_search.core.types import ErrorMode, Frequency, Layer, Period
+from boj_stat_search.core.types import Code, ErrorMode, Frequency, Layer, Period
 from boj_stat_search.core.url_builder import (
     build_data_code_api_url,
     build_data_layer_api_url,
@@ -126,8 +126,8 @@ def get_metadata(
 
 
 def get_data_code_raw(
-    db: str,
-    code: str,
+    db: str | None = None,
+    code: Code | str | None = None,
     start_date: Period | str | None = None,
     end_date: Period | str | None = None,
     start_position: int | None = None,
@@ -147,8 +147,8 @@ def get_data_code_raw(
 
 
 def get_data_code(
-    db: str,
-    code: str,
+    db: str | None = None,
+    code: Code | str | None = None,
     start_date: Period | str | None = None,
     end_date: Period | str | None = None,
     start_position: int | None = None,

--- a/src/boj_stat_search/client.py
+++ b/src/boj_stat_search/client.py
@@ -3,7 +3,7 @@ import time
 import httpx
 
 from boj_stat_search.api.api_request import get_data_code, get_data_layer, get_metadata
-from boj_stat_search.core.types import ErrorMode, Frequency, Layer, Period
+from boj_stat_search.core.types import Code, ErrorMode, Frequency, Layer, Period
 from boj_stat_search.models import DataResponse, MetadataResponse
 
 
@@ -55,8 +55,8 @@ class BojClient:
 
     def get_data_code(
         self,
-        db: str,
-        code: str,
+        db: str | None = None,
+        code: Code | str | None = None,
         start_date: Period | str | None = None,
         end_date: Period | str | None = None,
         start_position: int | None = None,

--- a/src/boj_stat_search/core/__init__.py
+++ b/src/boj_stat_search/core/__init__.py
@@ -4,16 +4,18 @@ from boj_stat_search.core.parser import (
     parse_data_code_response,
     parse_metadata_response,
 )
-from boj_stat_search.core.types import ErrorMode, Frequency, Layer, Period
+from boj_stat_search.core.types import Code, ErrorMode, Frequency, Layer, Period
 from boj_stat_search.core.url_builder import (
     build_data_code_api_url,
     build_data_layer_api_url,
     build_metadata_api_url,
 )
 from boj_stat_search.core.validator import (
+    coerce_code,
     coerce_frequency,
     coerce_layer,
     coerce_period,
+    extract_db_from_code,
     validate_data_code_params,
     validate_data_layer_params,
     validate_metadata_params,
@@ -26,6 +28,7 @@ __all__ = [
     "parse_metadata_response",
     "Frequency",
     "Layer",
+    "Code",
     "Period",
     "ErrorMode",
     "build_data_code_api_url",
@@ -33,7 +36,9 @@ __all__ = [
     "build_metadata_api_url",
     "coerce_frequency",
     "coerce_layer",
+    "coerce_code",
     "coerce_period",
+    "extract_db_from_code",
     "validate_data_code_params",
     "validate_data_layer_params",
     "validate_metadata_params",

--- a/src/boj_stat_search/core/url_builder.py
+++ b/src/boj_stat_search/core/url_builder.py
@@ -2,11 +2,13 @@ from typing import Any
 import warnings
 from urllib.parse import SplitResult, urlencode, urlunsplit
 
-from boj_stat_search.core.types import ErrorMode, Frequency, Layer, Period
+from boj_stat_search.core.types import Code, ErrorMode, Frequency, Layer, Period
 from boj_stat_search.core.validator import (
+    coerce_code,
     coerce_frequency,
     coerce_layer,
     coerce_period,
+    extract_db_from_code,
     validate_data_code_params,
     validate_data_layer_params,
     validate_metadata_params,
@@ -64,26 +66,35 @@ def build_metadata_api_url(
 
 
 def build_data_code_api_url(
-    db: str,
-    code: str,
+    db: str | None = None,
+    code: Code | str | None = None,
     start_date: Period | str | None = None,
     end_date: Period | str | None = None,
     start_position: int | None = None,
     on_validation_error: ErrorMode = "raise",
 ) -> str:
+    code_embedded_db = extract_db_from_code(code)
+    if db is not None and code_embedded_db is not None and db != code_embedded_db:
+        raise ValueError("db/code: conflicting DB values between db and Code input")
+
+    resolved_db = db if db is not None else code_embedded_db
+    normalized_code: Any = coerce_code(code)
     normalized_start_date: Any = coerce_period(start_date)
     normalized_end_date: Any = coerce_period(end_date)
 
     validation_errors = validate_data_code_params(
-        db=db,
-        code=code,
+        db=resolved_db,
+        code=normalized_code,
         start_date=normalized_start_date,
         end_date=normalized_end_date,
         start_position=start_position,
     )
     _handle_validation_errors(validation_errors, on_validation_error)
 
-    query_params: dict[str, str | int] = {"db": db, "code": code}
+    query_params: dict[str, Any] = {}
+    if resolved_db is not None:
+        query_params["db"] = resolved_db
+    query_params["code"] = normalized_code
     if normalized_start_date is not None:
         query_params["startDate"] = normalized_start_date
     if normalized_end_date is not None:

--- a/src/boj_stat_search/core/validator.py
+++ b/src/boj_stat_search/core/validator.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from boj_stat_search.core.database import list_db
-from boj_stat_search.core.types import Frequency, Layer, Period
+from boj_stat_search.core.types import Code, Frequency, Layer, Period
 
 
 FORBIDDEN_CHARS = ("<", ">", '"', "”", "!", "|", "\\", ";", "'")
@@ -21,6 +21,18 @@ def coerce_layer(layer: Any) -> Any:
     if isinstance(layer, Layer):
         return layer.to_api_value()
     return layer
+
+
+def coerce_code(code: Any) -> Any:
+    if isinstance(code, Code):
+        return code.to_api_value()
+    return code
+
+
+def extract_db_from_code(code: Any) -> str | None:
+    if isinstance(code, Code):
+        return code.db
+    return None
 
 
 def coerce_period(
@@ -148,8 +160,8 @@ def _validate_date_for_frequency(
 
 
 def validate_data_code_params(
-    db: str,
-    code: str,
+    db: str | None,
+    code: str | None,
     start_date: Period | str | None = None,
     end_date: Period | str | None = None,
     start_position: int | None = None,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, Mock, patch
 import httpx
 
 from boj_stat_search import BojClient
+from boj_stat_search.core.types import Code
 from boj_stat_search.models import DataResponse, MetadataResponse
 
 
@@ -159,6 +160,20 @@ def test_get_data_code_delegates_all_optional_args():
         )
     mock_fn.assert_called_once_with(
         "FM01", "STRDCLUCON", "202501", "202512", 10, "raise", client=c._client
+    )
+    assert result is expected
+
+
+def test_get_data_code_delegates_code_class_with_embedded_db():
+    expected = _make_data_response()
+    code = Code("FM01'STRDCLUCON")
+    with patch(
+        "boj_stat_search.client.get_data_code", return_value=expected
+    ) as mock_fn:
+        c = BojClient()
+        result = c.get_data_code(code=code)
+    mock_fn.assert_called_once_with(
+        None, code, None, None, None, "raise", client=c._client
     )
     assert result is expected
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -20,6 +20,7 @@ from boj_stat_search.catalog import (
     load_catalog_db as catalog_load_catalog_db,
     search_series as catalog_search_series,
 )
+from boj_stat_search.core import Code as CoreCode
 from boj_stat_search.core import Frequency as CoreFrequency
 from boj_stat_search.core import Layer as CoreLayer
 from boj_stat_search.core import Period as CorePeriod
@@ -54,6 +55,7 @@ def test_top_level_re_exports_functional_api():
 def test_top_level_re_exports_key_types_and_models():
     assert bss.Frequency is CoreFrequency
     assert bss.Layer is CoreLayer
+    assert bss.Code is CoreCode
     assert bss.Period is CorePeriod
     assert bss.MetadataExportReport is CatalogMetadataExportReport
     assert bss.CatalogError is CatalogCatalogError
@@ -83,6 +85,7 @@ def test_top_level_has_expected_public_symbols():
         "search_series",
         "Frequency",
         "Layer",
+        "Code",
         "Period",
         "MetadataExportReport",
         "CatalogError",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,6 @@
 import pytest
 
-from boj_stat_search.core.types import Frequency, Period
+from boj_stat_search.core.types import Code, Frequency, Period
 
 
 def test_period_year_constructor_returns_expected_value():
@@ -55,3 +55,63 @@ def test_period_rejects_invalid_quarter():
 def test_period_rejects_invalid_month():
     with pytest.raises(ValueError, match="month"):
         Period.month(2025, 13)
+
+
+def test_code_accepts_plain_series_code():
+    code = Code("MADR1Z@D")
+
+    assert code.db is None
+    assert code.codes == ("MADR1Z@D",)
+    assert code.to_api_value() == "MADR1Z@D"
+    assert str(code) == "MADR1Z@D"
+
+
+def test_code_accepts_db_code_format():
+    code = Code("IR01'MADR1Z@D")
+
+    assert code.db == "IR01"
+    assert code.codes == ("MADR1Z@D",)
+    assert code.to_api_value() == "MADR1Z@D"
+
+
+def test_code_accepts_mixed_prefixed_and_plain_values():
+    code = Code("IR01'A", "B")
+
+    assert code.db == "IR01"
+    assert code.codes == ("A", "B")
+    assert code.to_api_value() == "A,B"
+
+
+def test_code_rejects_conflicting_db_prefixes():
+    with pytest.raises(ValueError, match="conflicting DB"):
+        Code("IR01'A", "FM01'B")
+
+
+def test_code_rejects_empty_input():
+    with pytest.raises(ValueError, match="between 1 and 250"):
+        Code()
+
+
+def test_code_rejects_too_many_values():
+    with pytest.raises(ValueError, match="between 1 and 250"):
+        Code(*[f"S{i}" for i in range(251)])
+
+
+def test_code_rejects_non_string_value():
+    with pytest.raises(ValueError, match="must be a string"):
+        Code("A", 1)  # type: ignore[arg-type]
+
+
+def test_code_rejects_empty_string_value():
+    with pytest.raises(ValueError, match="non-empty"):
+        Code("")
+
+
+def test_code_rejects_empty_db_prefix_in_db_code_format():
+    with pytest.raises(ValueError, match="DB prefix"):
+        Code("'ABC")
+
+
+def test_code_rejects_empty_code_in_db_code_format():
+    with pytest.raises(ValueError, match="series code"):
+        Code("IR01'")

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,10 +1,12 @@
 import pytest
 
-from boj_stat_search.core.types import Frequency, Layer, Period
+from boj_stat_search.core.types import Code, Frequency, Layer, Period
 from boj_stat_search.core.validator import (
+    coerce_code,
     coerce_frequency,
     coerce_layer,
     coerce_period,
+    extract_db_from_code,
     validate_data_code_params,
     validate_data_layer_params,
     validate_metadata_params,
@@ -193,8 +195,20 @@ def test_coerce_layer_from_layer_returns_api_code():
     assert coerce_layer(Layer(1, 1, 1)) == "1,1,1"
 
 
+def test_coerce_code_from_code_returns_api_code():
+    assert coerce_code(Code("IR01'A", "IR01'B")) == "A,B"
+
+
 def test_coerce_period_from_period_returns_api_code():
     assert coerce_period(Period.month(2025, 4)) == "202504"
+
+
+def test_extract_db_from_code_returns_embedded_db():
+    assert extract_db_from_code(Code("IR01'A")) == "IR01"
+
+
+def test_extract_db_from_non_code_returns_none():
+    assert extract_db_from_code("A") is None
 
 
 def test_coerce_period_with_frequency_falls_back_to_raw_value():


### PR DESCRIPTION
## Summary
- add `Code` value object to parse `DB'CODE` format and normalize multi-series codes
- extend data-code URL building and API/client signatures to accept `Code` and optional `db`
- add hard conflict check when explicit `db` disagrees with embedded `Code` DB
- export `Code` from core and top-level package
- add test coverage for types, validator helpers, URL builder, API, client delegation, and public exports

Closes #29.

## Validation
- `UV_CACHE_DIR=.uv-cache uv run ruff format --check src tests`
- `UV_CACHE_DIR=.uv-cache uv run ruff check src tests`
- `UV_CACHE_DIR=.uv-cache uv run ty check`
- `UV_CACHE_DIR=.uv-cache uv run pytest -q` (`207 passed`)
