### PR TITLE
Auto-resolve db from local catalog for get_data_code

### DIFF
--- a/src/boj_stat_search/__init__.py
+++ b/src/boj_stat_search/__init__.py
@@ -17,6 +17,7 @@ from boj_stat_search.catalog import (
     list_series,
     load_catalog_all,
     load_catalog_db,
+    resolve_db,
     search_series,
 )
 from boj_stat_search.core import Code, Frequency, Layer, Period, list_db
@@ -44,6 +45,7 @@ __all__ = [
     "load_catalog_all",
     "list_series",
     "search_series",
+    "resolve_db",
     "Frequency",
     "Layer",
     "Code",

--- a/src/boj_stat_search/api/api_request.py
+++ b/src/boj_stat_search/api/api_request.py
@@ -12,6 +12,7 @@ from boj_stat_search.core.url_builder import (
     build_data_layer_api_url,
     build_metadata_api_url,
 )
+from boj_stat_search.core.validator import coerce_code, extract_db_from_code
 
 
 class BojApiError(httpx.HTTPStatusError):
@@ -135,6 +136,21 @@ def get_data_code_raw(
     *,
     client: httpx.Client | None = None,
 ) -> dict[str, Any]:
+    if db is None and extract_db_from_code(code) is None:
+        normalized_code = coerce_code(code)
+        first_code = (
+            normalized_code.split(",", 1)[0].strip()
+            if isinstance(normalized_code, str)
+            else None
+        )
+        if first_code:
+            try:
+                from boj_stat_search.catalog.search import resolve_db
+
+                db = resolve_db(first_code)
+            except Exception:
+                pass
+
     url = build_data_code_api_url(
         db=db,
         code=code,

--- a/src/boj_stat_search/catalog/__init__.py
+++ b/src/boj_stat_search/catalog/__init__.py
@@ -12,7 +12,7 @@ from boj_stat_search.catalog.loader import (
     load_catalog_all,
     load_catalog_db,
 )
-from boj_stat_search.catalog.search import list_series, search_series
+from boj_stat_search.catalog.search import list_series, resolve_db, search_series
 
 __all__ = [
     "METADATA_PARQUET_COLUMNS",
@@ -27,4 +27,5 @@ __all__ = [
     "load_catalog_all",
     "list_series",
     "search_series",
+    "resolve_db",
 ]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -18,6 +18,7 @@ from boj_stat_search.catalog import (
     list_series as catalog_list_series,
     load_catalog_all as catalog_load_catalog_all,
     load_catalog_db as catalog_load_catalog_db,
+    resolve_db as catalog_resolve_db,
     search_series as catalog_search_series,
 )
 from boj_stat_search.core import Code as CoreCode
@@ -49,6 +50,7 @@ def test_top_level_re_exports_functional_api():
     assert bss.load_catalog_all is catalog_load_catalog_all
     assert bss.list_series is catalog_list_series
     assert bss.search_series is catalog_search_series
+    assert bss.resolve_db is catalog_resolve_db
     assert bss.show_layers is display_show_layers
 
 
@@ -83,6 +85,7 @@ def test_top_level_has_expected_public_symbols():
         "load_catalog_all",
         "list_series",
         "search_series",
+        "resolve_db",
         "Frequency",
         "Layer",
         "Code",


### PR DESCRIPTION
## Summary
- add cache-only `resolve_db(series_code)` in catalog search to resolve DB from local parquet caches without downloads
- add best-effort DB auto-resolution in `get_data_code_raw` when `db` is omitted and `code` has no embedded DB
- keep fallback behavior non-breaking by swallowing resolver errors and letting normal validation proceed
- export `resolve_db` from `boj_stat_search.catalog` and top-level `boj_stat_search`
- add tests for resolver behavior, API fallback behavior, and public API exports

Closes #30.

## Validation
- `UV_CACHE_DIR=.uv-cache uv run ruff check src tests`
- `UV_CACHE_DIR=.uv-cache uv run ty check`
- `UV_CACHE_DIR=.uv-cache uv run pytest -q` (`219 passed`)
