### PR TITLE
Document issue #8 data-code usability behavior

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,5 +3,15 @@
 ## Sections
 
 - **[API Manual](./api_manual/)** — Documents the raw Bank of Japan Stat-Search Web API: endpoints, parameters, response shapes, and discrepancies between the official manual and observed behavior.
-- **[User Guide](./user_guide/)** — Explains how to use the `boj_stat_search` Python package: getting started, querying data, pagination, error handling, and layer tree display.
+- **[User Guide](./user_guide/)** — Explains how to use the `boj_stat_search` Python package: getting started, querying data, pagination, error handling, and layer tree display. Includes wrapper conveniences such as `Code` (`DB'CODE` input) and cache-based DB resolution for `get_data_code`.
 - **[Development Guide](./development_guide/)** — Covers branch policy, release process, versioning strategy, and metadata licensing determination for contributors.
+
+## Data Code Usability
+
+`boj_stat_search` provides higher-level Data Code ergonomics beyond the raw BOJ API:
+
+- Accept BOJ UI-style `DB'CODE` input via `Code` (for example, `Code("IR01'MADR1Z@D")`).
+- Allow omitting `db` in `get_data_code` when it can be inferred from local cached catalog data.
+- Expose `resolve_db` for explicit cache-only DB lookup by series code.
+
+For usage details and examples, see [User Guide: Querying Data](./user_guide/querying_data.md).

--- a/docs/api_manual/request_basics.md
+++ b/docs/api_manual/request_basics.md
@@ -29,6 +29,10 @@ Endpoint-specific parameters:
   - `startDate`, `endDate` (optional)
   - `startPosition` (optional, integer >= 1)
 
+> Note for `boj_stat_search` users: this page documents the raw BOJ API, where `db` is required.
+> The Python wrapper adds optional conveniences for `get_data_code` (for example `Code("DB'CODE")` input and cache-based DB resolution when `db` is omitted).
+> See [User Guide: Querying Data](../user_guide/querying_data.md).
+
 ## Date Format Rules
 
 From the official manual:

--- a/docs/user_guide/README.md
+++ b/docs/user_guide/README.md
@@ -5,13 +5,13 @@ This guide explains how to use `boj_stat_search` for common tasks.
 The package can be used in three ways:
 
 - **CLI** — the `boj-stat-search` command lets you query data directly from the terminal. JSON output is designed for piping to `jq` and other tools.
-- **Functional API** — top-level functions (`get_metadata`, `get_data_code`, `get_data_layer`, `generate_metadata_parquet_files`, `load_catalog_db`, `load_catalog_all`, `list_series`, `search_series`). Simple and composable; no built-in throttling, so callers must manage delays manually for batch use.
+- **Functional API** — top-level functions (`get_metadata`, `get_data_code`, `get_data_layer`, `generate_metadata_parquet_files`, `load_catalog_db`, `load_catalog_all`, `list_series`, `search_series`, `resolve_db`). Simple and composable; no built-in throttling, so callers must manage delays manually for batch use.
 - **`BojClient`** — a stateful client that wraps the functional API. Reuses a single HTTP connection and enforces a configurable minimum delay between requests (default 1 s). Preferred for batch workflows.
 
 ## Who This Is For
 
 - Users who want to fetch metadata or time-series data from BOJ Stat-Search.
-- Users who prefer typed helpers like `Frequency`, `Layer`, and `Period`.
+- Users who prefer typed helpers like `Code`, `Frequency`, `Layer`, and `Period`.
 - Users who want to inspect layer trees quickly with `show_layers`.
 
 ## Guide Map
@@ -32,12 +32,14 @@ The package can be used in three ways:
   - `load_catalog_all`
   - `list_series`
   - `search_series`
+  - `resolve_db`
   - `BojClient` (stateful client with built-in throttling)
   - `show_layers`
   - `list_db`
-  - `Frequency`, `Layer`, `Period`
+  - `Code`, `Frequency`, `Layer`, `Period`
   - `BojApiError`
   - `DataResponse`, `MetadataResponse`, `DbInfo`
+  - Data Code usability helpers (`DB'CODE` via `Code`, optional `db` with cache-based resolution)
   - Pagination, error handling, HTTP client reuse, throttling
 - Not covered:
   - raw API variants (`get_*_raw`)

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -48,6 +48,26 @@ print(len(metadata.result_set))
 - `db`: database name returned by the API
 - `result_set`: metadata entries
 
+## 4. Data Code Input Styles
+
+`get_data_code` supports multiple input styles:
+
+```python
+from boj_stat_search import Code, get_data_code
+
+# Explicit db + plain series code
+response_a = get_data_code(db="IR01", code="MADR1Z@D")
+
+# BOJ UI-style DB'CODE format
+response_b = get_data_code(code=Code("IR01'MADR1Z@D"))
+
+# Omit db (best-effort cache-based resolution)
+response_c = get_data_code(code="MADR1Z@D")
+```
+
+DB auto-resolution uses local cached catalog files only. It does not download metadata.
+If DB cannot be resolved from cache, provide `db` explicitly (or preload cache via `load_catalog_all` / `load_catalog_db`).
+
 ## Two API Styles
 
 `boj_stat_search` provides two ways to make requests:
@@ -64,7 +84,7 @@ The rest of this guide covers the functional API. For the stateful client, see [
 ## Top-Level API Used Here
 
 ```python
-from boj_stat_search import get_metadata, list_db
+from boj_stat_search import Code, get_data_code, get_metadata, list_db
 ```
 
 ## Next Step

--- a/docs/user_guide/querying_data.md
+++ b/docs/user_guide/querying_data.md
@@ -5,6 +5,7 @@ Fetch time-series values with typed parameters from the top-level API.
 ## Data by Series Code
 
 Use `get_data_code` when you already know series codes.
+`code` accepts plain string codes or the `Code` helper.
 
 ```python
 from boj_stat_search import Period, get_data_code
@@ -17,6 +18,44 @@ response = get_data_code(
 )
 
 print(response.status, len(response.result_set))
+```
+
+### Accepted `code` Forms
+
+Use plain code strings when you already know `db`:
+
+```python
+from boj_stat_search import get_data_code
+
+response = get_data_code(db="FM01", code="STRDCLUCON,STRACLUCON")
+```
+
+Use BOJ UI-style `DB'CODE` format with `Code`:
+
+```python
+from boj_stat_search import Code, get_data_code
+
+response = get_data_code(code=Code("IR01'MADR1Z@D"))
+response_multi = get_data_code(code=Code("IR01'A", "IR01'B"))
+```
+
+### Auto-Resolve `db` from Local Catalog Cache
+
+If `db` is omitted and `code` does not already embed DB information, `get_data_code` attempts to infer `db` from local cached catalog files.
+
+- Cache-only behavior: no metadata download is triggered by this resolution step.
+- For multiple codes in one call, resolution uses the first code.
+- If DB cannot be resolved (not found, ambiguous, or no cache), pass `db` explicitly.
+
+```python
+from boj_stat_search import get_data_code, resolve_db
+
+# Explicit resolution helper
+db = resolve_db("MADR1Z@D")
+response_a = get_data_code(db=db, code="MADR1Z@D")
+
+# Best-effort implicit resolution
+response_b = get_data_code(code="MADR1Z@D")
 ```
 
 ## Series Discovery with Local Catalog
@@ -246,12 +285,14 @@ get_data_layer(
 from boj_stat_search import (
     BojApiError,
     BojClient,
+    Code,
     Frequency,
     Layer,
     Period,
     get_data_code,
     get_data_layer,
     list_series,
+    resolve_db,
     search_series,
 )
 ```


### PR DESCRIPTION
## Summary
- confirm issue #8 implementation status in docs context (Proposal 1 from #29 and Proposal 2 from #30)
- update documentation index and user guide pages to cover Data Code usability improvements
- document `Code` (`DB'CODE` input), optional `db` behavior, and cache-only DB resolution guidance
- clarify raw BOJ API docs vs wrapper conveniences to prevent confusion

Closes #8.

## Updated Docs
- `docs/README.md`
- `docs/user_guide/README.md`
- `docs/user_guide/getting_started.md`
- `docs/user_guide/querying_data.md`
- `docs/api_manual/request_basics.md`
