### PR TITLE
Add two-layer API architecture docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,8 +3,8 @@
 ## Sections
 
 - **[API Manual](./api_manual/)** — Documents the raw Bank of Japan Stat-Search Web API: endpoints, parameters, response shapes, and discrepancies between the official manual and observed behavior.
-- **[User Guide](./user_guide/)** — Explains how to use the `boj_stat_search` Python package: getting started, querying data, pagination, error handling, and layer tree display. Includes wrapper conveniences such as `Code` (`DB'CODE` input) and cache-based DB resolution for `get_data_code`.
-- **[Development Guide](./development_guide/)** — Covers branch policy, release process, versioning strategy, and metadata licensing determination for contributors.
+- **[User Guide](./user_guide/)** — Explains how to use the `boj_stat_search` Python package: two-layer API architecture, getting started, querying data, pagination, error handling, and layer tree display. Includes wrapper conveniences such as `Code` (`DB'CODE` input) and cache-based DB resolution for `get_data_code`.
+- **[Development Guide](./development_guide/)** — Covers two-layer API architecture, branch policy, release process, versioning strategy, and metadata licensing determination for contributors.
 
 ## Data Code Usability
 

--- a/docs/development_guide/architecture.md
+++ b/docs/development_guide/architecture.md
@@ -1,0 +1,61 @@
+# Two-Layer API Architecture — Contributor Guide
+
+This document explains how the two-layer API architecture affects where new code should be added.
+
+## Layer Responsibilities
+
+### Low-Level API
+
+A faithful, thin wrapper around the original BOJ API.
+
+- Input parameters mirror the raw API (plain strings, no value objects).
+- Output structure mirrors the raw API response shape.
+- No validation, no pagination handling, no multi-request resolution.
+- Purpose: provide a stable, predictable 1-to-1 mapping to the upstream API.
+
+### High-Level API
+
+A user-facing layer that adds convenience and safety.
+
+- Accepts value objects (`Frequency`, `Layer`, `Period`) for validation and normalization.
+- Automatic pagination (fetches all pages transparently).
+- Transparent multi-request resolution: query patterns that require multiple API calls under the hood are handled automatically so the caller makes a single function call.
+- Purpose: let users focus on *what* data they want, not *how* to retrieve it.
+
+## Dependency Direction
+
+- High-level depends on low-level. **Never the reverse.**
+- Both layers are part of the public API — users can choose whichever suits their needs.
+
+## Where Does New Code Go?
+
+Use this checklist when adding or modifying functionality:
+
+| Change type | Target layer |
+|---|---|
+| New upstream API parameter passthrough | Low-level |
+| New response field passthrough | Low-level |
+| New convenience helper (auto-pagination, multi-request, etc.) | High-level |
+| New value object or enum | High-level |
+| New validation rule | High-level |
+| New `BojClient` method | High-level |
+| New CLI subcommand | High-level (CLI wraps high-level functions) |
+| Bug fix in raw API mapping | Low-level |
+| Bug fix in validation or convenience logic | High-level |
+
+## API Styles per Layer
+
+| Layer | Functional API | Client API (`BojClient`) | CLI |
+|---|---|---|---|
+| Low-level | Yes | — | — |
+| High-level | Yes | Yes | Yes |
+
+The client API adds HTTP connection reuse and automatic throttling, which are primarily useful in batch workflows where the high-level API is the natural choice.
+
+The CLI tracks the high-level functional API. Each CLI subcommand is a thin wrapper that parses arguments, calls the corresponding high-level function, and formats the output. Low-level API features are not exposed through the CLI — users who need that level of control are expected to use the Python API directly.
+
+## Key Principles
+
+1. **Keep the low-level layer stable.** Changes should track upstream API changes only.
+2. **Add convenience in the high-level layer.** If you're adding validation, pagination, or multi-request logic, it belongs in the high-level layer.
+3. **Respect the dependency direction.** High-level imports low-level. Low-level must never import from high-level.

--- a/docs/user_guide/README.md
+++ b/docs/user_guide/README.md
@@ -16,10 +16,11 @@ The package can be used in three ways:
 
 ## Guide Map
 
-1. [Getting Started](./getting_started.md)
-2. [Querying Data](./querying_data.md)
-3. [Layer Tree Display](./layer_tree_display.md)
-4. [Command-Line Interface](./cli.md)
+1. [Architecture](./architecture.md)
+2. [Getting Started](./getting_started.md)
+3. [Querying Data](./querying_data.md)
+4. [Layer Tree Display](./layer_tree_display.md)
+5. [Command-Line Interface](./cli.md)
 
 ## Coverage
 

--- a/docs/user_guide/architecture.md
+++ b/docs/user_guide/architecture.md
@@ -1,0 +1,65 @@
+# Two-Layer API Architecture
+
+`boj_stat_search` is organized into two API layers. Understanding the distinction helps you choose the right functions for your use case.
+
+## Low-Level API
+
+A thin, faithful wrapper around the raw BOJ Stat-Search Web API.
+
+- Parameters are plain strings, matching the upstream API exactly.
+- Response structure mirrors the raw JSON response shape.
+- No validation, no pagination handling, no multi-request resolution.
+- Useful when you need full control or want to replicate raw API behavior.
+
+```python
+from boj_stat_search import get_data_code_raw
+
+response = get_data_code_raw(db="IR01", code="MADR1Z@D")
+```
+
+## High-Level API
+
+A user-facing layer built on top of the low-level API. This is the layer most users should reach for.
+
+- Accepts value objects (`Frequency`, `Layer`, `Period`) for validation and normalization.
+- Automatic pagination — fetches all pages transparently when needed.
+- Transparent multi-request resolution — query patterns that require multiple API calls under the hood are handled automatically so you make a single function call.
+- Parameter validation with configurable error handling (`raise`, `warn`, `ignore`).
+
+```python
+from boj_stat_search import Frequency, Layer, Period, get_data_layer
+
+response = get_data_layer(
+    db="BP01",
+    frequency=Frequency.MONTHLY,
+    layer=Layer(1, 1, 1),
+    start_date=Period.month(2025, 4),
+    end_date=Period.month(2025, 9),
+)
+```
+
+## Which Layer Should I Use?
+
+| Concern | Low-level | High-level |
+|---|---|---|
+| Parameter types | Plain strings | Value objects (`Frequency`, `Layer`, `Period`) |
+| Validation | None | Configurable (`raise` / `warn` / `ignore`) |
+| Pagination | Manual | Automatic |
+| Multi-request resolution | Manual | Automatic |
+| Response shape | Mirrors raw API | Parsed into typed objects |
+| When to use | Full control, debugging, advanced scripting | Most everyday use cases |
+
+## API Styles per Layer
+
+| Layer | Functional API | `BojClient` | CLI |
+|---|---|---|---|
+| Low-level | Yes | — | — |
+| High-level | Yes | Yes | Yes |
+
+- **Functional API** — stateless functions. Available for both layers.
+- **`BojClient`** — adds HTTP connection reuse and automatic throttling. Available for the high-level layer only, where batch workflows are the natural use case.
+- **CLI** — each subcommand is a thin wrapper around a high-level function. Low-level API features are not exposed through the CLI; users who need that level of control should use the Python API directly.
+
+## Next Step
+
+The rest of this guide covers the high-level API. For low-level details, refer to the [API Manual](../api_manual/) which documents the upstream endpoints that the low-level layer wraps 1-to-1.


### PR DESCRIPTION
## Summary
- Add `docs/user_guide/architecture.md` explaining the low-level vs high-level API layers for end users
- Add `docs/development_guide/architecture.md` with contributor guidance on where new code belongs
- Update `docs/README.md` and `docs/user_guide/README.md` to link to the new pages

Closes #38

## Test plan
- [ ] Verify all internal doc links resolve correctly
- [ ] Review content against issue #38 requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)