### PR TITLE
Move catalog row parsing/validation from shell to core (#46)

### DIFF
--- a/src/boj_stat_search/core/__init__.py
+++ b/src/boj_stat_search/core/__init__.py
@@ -1,3 +1,9 @@
+from boj_stat_search.core.catalog_parser import (
+    REQUIRED_COLUMNS,
+    ensure_required_columns,
+    row_to_entry,
+    table_to_entries,
+)
 from boj_stat_search.core.database import list_db
 from boj_stat_search.core.formatter import format_layer_tree
 from boj_stat_search.core.parser import (
@@ -22,6 +28,10 @@ from boj_stat_search.core.validator import (
 )
 
 __all__ = [
+    "REQUIRED_COLUMNS",
+    "ensure_required_columns",
+    "row_to_entry",
+    "table_to_entries",
     "list_db",
     "format_layer_tree",
     "parse_data_code_response",

--- a/src/boj_stat_search/core/catalog_parser.py
+++ b/src/boj_stat_search/core/catalog_parser.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pyarrow as pa
+
+from boj_stat_search.core.models import SeriesCatalogEntry
+
+REQUIRED_COLUMNS: tuple[str, ...] = (
+    "db",
+    "series_code",
+    "name_j",
+    "name_en",
+    "unit_j",
+    "unit_en",
+    "frequency",
+    "category_j",
+    "category_en",
+    "layer1",
+    "layer2",
+    "layer3",
+    "layer4",
+    "layer5",
+    "start_of_time_series",
+    "end_of_time_series",
+    "last_update",
+    "notes_j",
+    "notes_en",
+)
+
+
+def table_to_entries(table: pa.Table) -> tuple[SeriesCatalogEntry, ...]:
+    ensure_required_columns(table.column_names)
+
+    entries: list[SeriesCatalogEntry] = []
+    for row in table.to_pylist():
+        entries.append(row_to_entry(row))
+    return tuple(entries)
+
+
+def ensure_required_columns(column_names: list[str]) -> None:
+    missing = [column for column in REQUIRED_COLUMNS if column not in column_names]
+    if missing:
+        raise ValueError(
+            "Catalog table is missing required columns: " + ", ".join(missing)
+        )
+
+
+def row_to_entry(row: dict[str, Any]) -> SeriesCatalogEntry:
+    return SeriesCatalogEntry(
+        db=_required_str(row, "db"),
+        series_code=_required_str(row, "series_code"),
+        name_j=_required_str(row, "name_j"),
+        name_en=_required_str(row, "name_en"),
+        unit_j=_required_str(row, "unit_j"),
+        unit_en=_required_str(row, "unit_en"),
+        frequency=_required_str(row, "frequency"),
+        category_j=_required_str(row, "category_j"),
+        category_en=_required_str(row, "category_en"),
+        layer1=_required_int(row, "layer1"),
+        layer2=_required_int(row, "layer2"),
+        layer3=_required_int(row, "layer3"),
+        layer4=_required_int(row, "layer4"),
+        layer5=_required_int(row, "layer5"),
+        start_of_time_series=_required_str(row, "start_of_time_series"),
+        end_of_time_series=_required_str(row, "end_of_time_series"),
+        last_update=_required_str(row, "last_update"),
+        notes_j=_required_str(row, "notes_j"),
+        notes_en=_required_str(row, "notes_en"),
+    )
+
+
+def _required_str(row: dict[str, Any], field: str) -> str:
+    value = row[field]
+    if not isinstance(value, str):
+        raise ValueError(f"{field}: must be a string")
+    return value
+
+
+def _required_int(row: dict[str, Any], field: str) -> int:
+    value = row[field]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field}: must be an integer")
+    return value

--- a/src/boj_stat_search/shell/catalog/search.py
+++ b/src/boj_stat_search/shell/catalog/search.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
 
 import httpx
 import pyarrow as pa
@@ -18,32 +17,15 @@ from boj_stat_search.shell.catalog.loader import (
     load_catalog_all,
     load_catalog_db,
 )
-from boj_stat_search.core import Layer, list_db
+from boj_stat_search.core import (
+    Layer,
+    list_db,
+    table_to_entries as _core_table_to_entries,
+)
 from boj_stat_search.core.validator import coerce_layer
 from boj_stat_search.core.models import SeriesCatalogEntry
 
 _SEARCH_FIELDS: tuple[str, ...] = ("name_j", "name_en", "category_j", "category_en")
-_REQUIRED_COLUMNS: tuple[str, ...] = (
-    "db",
-    "series_code",
-    "name_j",
-    "name_en",
-    "unit_j",
-    "unit_en",
-    "frequency",
-    "category_j",
-    "category_en",
-    "layer1",
-    "layer2",
-    "layer3",
-    "layer4",
-    "layer5",
-    "start_of_time_series",
-    "end_of_time_series",
-    "last_update",
-    "notes_j",
-    "notes_en",
-)
 
 
 def search_series(
@@ -281,58 +263,7 @@ def _row_matches_keyword(row: SeriesCatalogEntry, normalized_keyword: str) -> bo
 
 
 def _table_to_entries(table: pa.Table) -> tuple[SeriesCatalogEntry, ...]:
-    _ensure_required_columns(table.column_names)
-
-    entries: list[SeriesCatalogEntry] = []
-    for row in table.to_pylist():
-        entries.append(_row_to_entry(row))
-    return tuple(entries)
-
-
-def _ensure_required_columns(column_names: list[str]) -> None:
-    missing = [column for column in _REQUIRED_COLUMNS if column not in column_names]
-    if missing:
-        raise CatalogError(
-            "Catalog table is missing required columns: " + ", ".join(missing)
-        )
-
-
-def _row_to_entry(row: dict[str, Any]) -> SeriesCatalogEntry:
     try:
-        return SeriesCatalogEntry(
-            db=_required_str(row, "db"),
-            series_code=_required_str(row, "series_code"),
-            name_j=_required_str(row, "name_j"),
-            name_en=_required_str(row, "name_en"),
-            unit_j=_required_str(row, "unit_j"),
-            unit_en=_required_str(row, "unit_en"),
-            frequency=_required_str(row, "frequency"),
-            category_j=_required_str(row, "category_j"),
-            category_en=_required_str(row, "category_en"),
-            layer1=_required_int(row, "layer1"),
-            layer2=_required_int(row, "layer2"),
-            layer3=_required_int(row, "layer3"),
-            layer4=_required_int(row, "layer4"),
-            layer5=_required_int(row, "layer5"),
-            start_of_time_series=_required_str(row, "start_of_time_series"),
-            end_of_time_series=_required_str(row, "end_of_time_series"),
-            last_update=_required_str(row, "last_update"),
-            notes_j=_required_str(row, "notes_j"),
-            notes_en=_required_str(row, "notes_en"),
-        )
+        return _core_table_to_entries(table)
     except ValueError as exc:
-        raise CatalogError("Catalog row contains invalid values") from exc
-
-
-def _required_str(row: dict[str, Any], field: str) -> str:
-    value = row[field]
-    if not isinstance(value, str):
-        raise ValueError(f"{field}: must be a string")
-    return value
-
-
-def _required_int(row: dict[str, Any], field: str) -> int:
-    value = row[field]
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise ValueError(f"{field}: must be an integer")
-    return value
+        raise CatalogError(str(exc)) from exc

--- a/src/boj_stat_search/shell/cli.py
+++ b/src/boj_stat_search/shell/cli.py
@@ -4,7 +4,12 @@ from typing import Annotated, Optional
 
 import typer
 
-from boj_stat_search.shell.api import BojApiError, get_data_code, get_data_layer, get_metadata
+from boj_stat_search.shell.api import (
+    BojApiError,
+    get_data_code,
+    get_data_layer,
+    get_metadata,
+)
 from boj_stat_search.shell.catalog.exporter import generate_metadata_parquet_files
 from boj_stat_search.core import list_db
 from boj_stat_search.shell.display import show_layers

--- a/tests/test_catalog_parser.py
+++ b/tests/test_catalog_parser.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+from boj_stat_search.core.catalog_parser import (
+    ensure_required_columns,
+    row_to_entry,
+    table_to_entries,
+    REQUIRED_COLUMNS,
+)
+from boj_stat_search.core.models import SeriesCatalogEntry
+
+
+def _make_row(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "db": "BS",
+        "series_code": "BS01'MABJMBS_MA_C__CM_S111",
+        "name_j": "テスト",
+        "name_en": "Test",
+        "unit_j": "百万円",
+        "unit_en": "million yen",
+        "frequency": "Monthly",
+        "category_j": "カテゴリ",
+        "category_en": "Category",
+        "layer1": 1,
+        "layer2": 2,
+        "layer3": 3,
+        "layer4": 4,
+        "layer5": 5,
+        "start_of_time_series": "2000-01",
+        "end_of_time_series": "2024-12",
+        "last_update": "2025-01-01",
+        "notes_j": "備考",
+        "notes_en": "Notes",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_table(rows: list[dict[str, object]] | None = None) -> pa.Table:
+    if rows is None:
+        rows = [_make_row()]
+    if not rows:
+        schema = pa.schema([(col, pa.string()) for col in REQUIRED_COLUMNS])
+        return pa.table(
+            {col: pa.array([], type=pa.string()) for col in REQUIRED_COLUMNS},
+            schema=schema,
+        )
+    keys = list(rows[0].keys())
+    data = {k: [row[k] for row in rows] for k in keys}
+    return pa.table(data)
+
+
+# ---------------------------------------------------------------------------
+# ensure_required_columns
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_required_columns_passes_with_all_columns() -> None:
+    ensure_required_columns(list(REQUIRED_COLUMNS))
+
+
+def test_ensure_required_columns_passes_with_extra_columns() -> None:
+    cols = list(REQUIRED_COLUMNS) + ["extra"]
+    ensure_required_columns(cols)
+
+
+def test_ensure_required_columns_raises_when_column_missing() -> None:
+    cols = [c for c in REQUIRED_COLUMNS if c != "db"]
+    with pytest.raises(ValueError, match="db"):
+        ensure_required_columns(cols)
+
+
+def test_ensure_required_columns_error_includes_all_missing() -> None:
+    cols = [c for c in REQUIRED_COLUMNS if c not in ("db", "series_code")]
+    with pytest.raises(ValueError) as exc_info:
+        ensure_required_columns(cols)
+    msg = str(exc_info.value)
+    assert "db" in msg
+    assert "series_code" in msg
+
+
+# ---------------------------------------------------------------------------
+# row_to_entry
+# ---------------------------------------------------------------------------
+
+
+def test_row_to_entry_returns_correct_entry() -> None:
+    row = _make_row()
+    entry = row_to_entry(row)
+    assert isinstance(entry, SeriesCatalogEntry)
+    assert entry.db == "BS"
+    assert entry.layer1 == 1
+    assert entry.layer5 == 5
+    assert entry.name_en == "Test"
+
+
+def test_row_to_entry_raises_on_non_string_field() -> None:
+    row = _make_row(name_j=123)
+    with pytest.raises(ValueError, match="name_j"):
+        row_to_entry(row)
+
+def test_row_to_entry_raises_on_non_int_layer() -> None:
+    row = _make_row(layer1="one")
+    with pytest.raises(ValueError, match="layer1"):
+        row_to_entry(row)
+
+def test_row_to_entry_raises_on_bool_layer() -> None:
+    row = _make_row(layer1=True)
+    with pytest.raises(ValueError, match="layer1"):
+        row_to_entry(row)
+
+# ---------------------------------------------------------------------------
+# table_to_entries
+# ---------------------------------------------------------------------------
+
+
+def test_table_to_entries_converts_multi_row_table() -> None:
+    rows = [_make_row(series_code=f"CODE{i}") for i in range(3)]
+    table = _make_table(rows)
+    entries = table_to_entries(table)
+    assert len(entries) == 3
+    assert all(isinstance(e, SeriesCatalogEntry) for e in entries)
+    assert {e.series_code for e in entries} == {"CODE0", "CODE1", "CODE2"}
+
+
+def test_table_to_entries_empty_table_returns_empty_tuple() -> None:
+    table = _make_table([])
+    entries = table_to_entries(table)
+    assert entries == ()
+
+
+def test_table_to_entries_raises_on_missing_columns() -> None:
+    table = pa.table({"db": ["BS"], "series_code": ["X"]})
+    with pytest.raises(ValueError, match="missing required columns"):
+        table_to_entries(table)
+
+
+def test_table_to_entries_raises_on_invalid_row_data() -> None:
+    rows = [_make_row(layer1="bad")]
+    table = _make_table(rows)
+    with pytest.raises(ValueError, match="layer1"):
+        table_to_entries(table)

--- a/tests/test_catalog_search.py
+++ b/tests/test_catalog_search.py
@@ -9,7 +9,12 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
-from boj_stat_search.shell.catalog import CatalogError, list_series, resolve_db, search_series
+from boj_stat_search.shell.catalog import (
+    CatalogError,
+    list_series,
+    resolve_db,
+    search_series,
+)
 from boj_stat_search.core import Layer
 from boj_stat_search.core.models import SeriesCatalogEntry
 
@@ -153,7 +158,9 @@ def test_search_series_with_db_uses_load_catalog_db(monkeypatch) -> None:
     )
     load_all = Mock()
     monkeypatch.setattr("boj_stat_search.shell.catalog.search.load_catalog_db", load_db)
-    monkeypatch.setattr("boj_stat_search.shell.catalog.search.load_catalog_all", load_all)
+    monkeypatch.setattr(
+        "boj_stat_search.shell.catalog.search.load_catalog_all", load_all
+    )
 
     results = search_series("call", db="FM01")
 
@@ -182,7 +189,9 @@ def test_search_series_with_dbs_uses_load_catalog_all(monkeypatch) -> None:
         )
     )
     load_db = Mock()
-    monkeypatch.setattr("boj_stat_search.shell.catalog.search.load_catalog_all", load_all)
+    monkeypatch.setattr(
+        "boj_stat_search.shell.catalog.search.load_catalog_all", load_all
+    )
     monkeypatch.setattr("boj_stat_search.shell.catalog.search.load_catalog_db", load_db)
 
     results = search_series("rate", dbs=["FM01", "BP01", "FM01"])
@@ -201,7 +210,9 @@ def test_search_series_rejects_db_and_dbs_together() -> None:
 def test_search_series_returns_empty_for_empty_dbs(monkeypatch) -> None:
     load_all = Mock()
     load_db = Mock()
-    monkeypatch.setattr("boj_stat_search.shell.catalog.search.load_catalog_all", load_all)
+    monkeypatch.setattr(
+        "boj_stat_search.shell.catalog.search.load_catalog_all", load_all
+    )
     monkeypatch.setattr("boj_stat_search.shell.catalog.search.load_catalog_db", load_db)
 
     results = search_series("rate", dbs=[])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -55,7 +55,9 @@ def test_context_manager_closes_internal_client_on_exit():
 
 def test_context_manager_delegates_get_metadata():
     expected = _make_metadata_response()
-    with patch("boj_stat_search.shell.client.get_metadata", return_value=expected) as mock_fn:
+    with patch(
+        "boj_stat_search.shell.client.get_metadata", return_value=expected
+    ) as mock_fn:
         with BojClient() as c:
             result = c.get_metadata("IR01")
     mock_fn.assert_called_once_with("IR01", "raise", client=c._client)
@@ -106,7 +108,9 @@ def test_explicit_close_does_not_close_external_client():
 def test_external_client_is_used_for_requests():
     external = Mock(spec=httpx.Client)
     expected = _make_metadata_response()
-    with patch("boj_stat_search.shell.client.get_metadata", return_value=expected) as mock_fn:
+    with patch(
+        "boj_stat_search.shell.client.get_metadata", return_value=expected
+    ) as mock_fn:
         c = BojClient(client=external)
         result = c.get_metadata("IR01")
     mock_fn.assert_called_once_with("IR01", "raise", client=external)
@@ -120,7 +124,9 @@ def test_external_client_is_used_for_requests():
 
 def test_get_metadata_delegates_to_functional_api():
     expected = _make_metadata_response()
-    with patch("boj_stat_search.shell.client.get_metadata", return_value=expected) as mock_fn:
+    with patch(
+        "boj_stat_search.shell.client.get_metadata", return_value=expected
+    ) as mock_fn:
         c = BojClient()
         result = c.get_metadata("IR01")
     mock_fn.assert_called_once_with("IR01", "raise", client=c._client)
@@ -307,7 +313,9 @@ def test_on_validation_error_default_is_raise():
 
 def test_on_validation_error_forwarded_to_get_metadata():
     expected = _make_metadata_response()
-    with patch("boj_stat_search.shell.client.get_metadata", return_value=expected) as mock_fn:
+    with patch(
+        "boj_stat_search.shell.client.get_metadata", return_value=expected
+    ) as mock_fn:
         c = BojClient(on_validation_error="warn")
         c.get_metadata("IR01")
     mock_fn.assert_called_once_with("IR01", "warn", client=c._client)


### PR DESCRIPTION
## What changed and why

Moves five pure helper functions and the `REQUIRED_COLUMNS` constant out of `shell/catalog/search.py` into a new `core/catalog_parser.py` module, aligning the codebase with the Functional Core / Imperative Shell architecture.

**New public API in `core/catalog_parser.py`:**
- `REQUIRED_COLUMNS` — constant listing required Parquet columns
- `table_to_entries` — converts a `pa.Table` to a tuple of `SeriesCatalogEntry`
- `ensure_required_columns` — validates column presence, raises `ValueError`
- `row_to_entry` — parses a single row dict into `SeriesCatalogEntry`, raises `ValueError`
- `_required_str` / `_required_int` — private field extractors (unchanged)

**Shell boundary (`shell/catalog/search.py`):**
- All moved functions removed; replaced by a thin `_table_to_entries` wrapper that catches `ValueError` → `CatalogError`. Call sites are unchanged.

All four symbols are re-exported from `core/__init__.py`.

## Affected modules

- `src/boj_stat_search/core/catalog_parser.py` (**new**)
- `src/boj_stat_search/core/__init__.py` (re-exports added)
- `src/boj_stat_search/shell/catalog/search.py` (moved code removed, wrapper added)
- `tests/test_catalog_parser.py` (**new**, 13 unit tests)

## Test evidence

```
uv run pytest -q
231 passed in 5.64s
```

## Compatibility notes

No public API changes. `CatalogError` is still raised by the shell on bad catalog data; internal `ValueError` is now raised (and caught) at the core/shell boundary.