### PR TITLE
Add development guide index and testing layout policy docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,15 @@
 - Tests: `tests/` (`test_api_request.py`, `test_parser.py`, `test_url_builder.py`, `test_validator.py`).
 - Reference docs and experiments: `notes/` and `docs/` (not production code).
 
+## Development Guide Docs
+
+- Entry point: `docs/development_guide/README.md`.
+- Architecture boundary and placement rules: `docs/development_guide/architecture.md`.
+- Test strategy and target test layout (`tests/core/`, `tests/shell/`): `docs/development_guide/testing.md`.
+- Release flow and branch policy: `docs/development_guide/release_process.md`.
+- Metadata redistribution/compliance notes: `docs/development_guide/metadata_licensing.md`.
+- When changing module placement, testing approach, release workflow, or metadata handling, update the corresponding development guide doc in the same PR.
+
 ## Build, Test, and Development Commands
 
 - Install/sync environment: `uv sync`

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ print(len(series))
 
 ## Documentation
 
+- [Documentation Home](./docs/README.md)
 - [User Guide](./docs/user_guide/README.md)
+- [Development Guide](./docs/development_guide/README.md)
 - [Metadata Licensing Determination](./docs/development_guide/metadata_licensing.md)
 
 ## Official Resources

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 - **[API Manual](./api_manual/)** — Documents the raw Bank of Japan Stat-Search Web API: endpoints, parameters, response shapes, and discrepancies between the official manual and observed behavior.
 - **[User Guide](./user_guide/)** — Explains how to use the `boj_stat_search` Python package: two-layer API architecture, getting started, querying data, pagination, error handling, and layer tree display. Includes wrapper conveniences such as `Code` (`DB'CODE` input) and cache-based DB resolution for `get_data_code`.
-- **[Development Guide](./development_guide/)** — Covers two-layer API architecture, branch policy, release process, versioning strategy, and metadata licensing determination for contributors.
+- **[Development Guide](./development_guide/README.md)** — Contributor docs for internal architecture boundaries, testing strategy, release process, and metadata licensing/compliance.
 
 ## Data Code Usability
 

--- a/docs/development_guide/README.md
+++ b/docs/development_guide/README.md
@@ -1,0 +1,27 @@
+# Development Guide
+
+This guide is for contributors maintaining `boj_stat_search` internals, tests,
+and release/compliance workflows.
+
+It complements the user-focused documentation in `docs/user_guide/` and the
+raw BOJ endpoint reference in `docs/api_manual/`.
+
+## Guide Map
+
+1. [Architecture](./architecture.md): Functional Core / Imperative Shell
+   boundaries and module placement rules.
+2. [Testing Strategy](./testing.md): Architecture-aligned test strategy: heavy
+   core tests, thin shell tests.
+3. [Release Process and Branch Policy](./release_process.md): Branch model,
+   release flow, version bumping, tagging, and pre-release checks.
+4. [Metadata Licensing Determination](./metadata_licensing.md): BOJ metadata
+   redistribution determination and operational compliance rules.
+
+## How To Use This Guide
+
+- Start with [Architecture](./architecture.md) before adding or moving modules.
+- Follow [Testing Strategy](./testing.md) when adding or changing behavior.
+- Use [Release Process and Branch Policy](./release_process.md) for release
+  preparation and tagging.
+- Re-check [Metadata Licensing Determination](./metadata_licensing.md) whenever
+  metadata generation/distribution behavior changes.

--- a/docs/development_guide/architecture.md
+++ b/docs/development_guide/architecture.md
@@ -1,5 +1,7 @@
 # Functional Core / Imperative Shell Architecture
 
+Part of the [Development Guide](./README.md).
+
 This project follows the Functional Core / Imperative Shell pattern at the
 directory level.
 

--- a/docs/development_guide/metadata_licensing.md
+++ b/docs/development_guide/metadata_licensing.md
@@ -1,5 +1,7 @@
 # Metadata Licensing Determination
 
+Part of the [Development Guide](./README.md).
+
 ## Scope
 
 This note documents whether this repository can redistribute BOJ Stat-Search

--- a/docs/development_guide/release_process.md
+++ b/docs/development_guide/release_process.md
@@ -1,5 +1,7 @@
 # Release Process and Branch Policy
 
+Part of the [Development Guide](./README.md).
+
 ## Branch Structure
 
 | Branch | Purpose |

--- a/docs/development_guide/testing.md
+++ b/docs/development_guide/testing.md
@@ -1,0 +1,140 @@
+# Testing Strategy
+
+Part of the [Development Guide](./README.md). See
+[Architecture](./architecture.md) for the module boundary this strategy follows.
+
+This project uses a Functional Core / Imperative Shell architecture (see
+`docs/development_guide/architecture.md`). Our tests follow the same boundary:
+
+- `core/` tests are comprehensive and logic-focused.
+- `shell/` tests are thin and boundary-focused.
+
+## Testing Principles
+
+1. Mirror architecture boundaries in tests.
+2. Put business and transformation logic tests in `core` targets.
+3. Keep `shell` tests lightweight: verify orchestration, side effects, and
+   integration boundaries only.
+4. Avoid real network calls in unit tests.
+5. Use descriptive test names that describe behavior, not implementation.
+
+## `tests/` Directory Structure
+
+`tests/` should mirror the same Functional Core / Imperative Shell boundary as
+`src/boj_stat_search/`.
+
+Target structure:
+
+```text
+tests/
+├── core/
+│   ├── test_types.py
+│   ├── test_validator.py
+│   ├── test_url_builder.py
+│   ├── test_parser.py
+│   ├── test_formatter.py
+│   └── test_catalog_parser.py
+└── shell/
+    ├── test_api_request.py
+    ├── test_client.py
+    ├── test_cli.py
+    ├── test_display.py
+    ├── test_catalog_loader.py
+    ├── test_catalog_search.py
+    ├── test_metadata_export.py
+    └── test_public_api.py
+```
+
+### Core-Oriented Test Modules
+
+These target modules under `src/boj_stat_search/core/` and should remain
+logic-heavy.
+
+| Test file | Primary target |
+|---|---|
+| `tests/core/test_types.py` | `core/types.py` |
+| `tests/core/test_validator.py` | `core/validator.py` |
+| `tests/core/test_url_builder.py` | `core/url_builder.py` |
+| `tests/core/test_parser.py` | `core/parser.py` |
+| `tests/core/test_formatter.py` | `core/formatter.py` |
+| `tests/core/test_catalog_parser.py` | `core/catalog_parser.py` |
+
+### Shell-Oriented Test Modules
+
+These target modules under `src/boj_stat_search/shell/` and should remain
+thin.
+
+| Test file | Primary target |
+|---|---|
+| `tests/shell/test_api_request.py` | `shell/api.py` |
+| `tests/shell/test_client.py` | `shell/client.py` |
+| `tests/shell/test_cli.py` | `shell/cli.py` |
+| `tests/shell/test_display.py` | `shell/display.py` |
+| `tests/shell/test_catalog_loader.py` | `shell/catalog/loader.py` |
+| `tests/shell/test_catalog_search.py` | `shell/catalog/search.py` |
+| `tests/shell/test_metadata_export.py` | `shell/catalog/exporter.py` |
+
+### Public API Surface
+
+| Test file | Primary target |
+|---|---|
+| `tests/shell/test_public_api.py` | top-level re-export contract in `src/boj_stat_search/__init__.py` |
+
+## Migration Note
+
+This guide defines the target test layout first. Actual file moves from the
+current flat `tests/` layout into `tests/core/` and `tests/shell/` can be done
+in a later change without altering the strategy in this document.
+
+## Core Testing Strategy (Comprehensive / Heavy)
+
+For `core` targets:
+
+- Do not use test doubles (no `Mock`, `patch`, `monkeypatch`) to simulate core
+  behavior.
+- Test real logic with representative and edge-case inputs.
+- Prefer broad scenario matrices, including:
+  - valid/happy-path transformations,
+  - invalid/edge inputs,
+  - explicit error messages and modes (`raise`, `warn`, `ignore`) where
+    applicable,
+  - boundary values for parsing, validation, and formatting.
+- Assert final values and structures, not intermediate implementation details.
+
+Rationale: `core` is where correctness lives. Tests should maximize confidence
+in deterministic behavior.
+
+## Shell Testing Strategy (Thin / Lightweight)
+
+For `shell` targets:
+
+- Use test doubles as needed for external boundaries:
+  - HTTP clients/responses,
+  - filesystem and cache boundaries,
+  - CLI output and process-facing behavior.
+- Verify orchestration and contracts:
+  - correct call delegation,
+  - correct argument forwarding to `core`,
+  - error propagation/translation,
+  - expected side effects at the boundary.
+- Do not duplicate `core` logic tests in `shell` tests.
+
+Rationale: `shell` should coordinate side effects, not own business logic.
+
+## Rule of Thumb for New Tests
+
+1. If behavior is pure and deterministic, place it in `core` and test it
+   heavily without doubles. Put the test module under `tests/core/`.
+2. If behavior touches I/O, HTTP, CLI, or mutable runtime state, keep it in
+   `shell` and test it with thin boundary tests (using doubles when needed).
+   Put the test module under `tests/shell/`.
+3. If a `shell` module accumulates non-trivial logic, move that logic into
+   `core` and add comprehensive `core` tests there.
+
+## Test Commands
+
+```bash
+uv run pytest -q
+uv run ruff check src tests
+uv run ty check
+```


### PR DESCRIPTION
## Summary
- add docs/development_guide/README.md as the contributor-facing entry point
- add docs/development_guide/testing.md with Functional Core / Imperative Shell testing strategy
- document the target future test layout split into tests/core/ and tests/shell/ (doc-only, no file moves)
- add development guide backlinks in architecture/release/metadata docs
- update docs/README.md, root README.md, and AGENTS.md to reference the development guide

## Scope
- documentation-only changes
- no runtime or API behavior changes

## Validation
- docs-only update; tests not run