### PR TITLE
fix: skip corrupted cache parquet in resolve_db and warn

### DIFF
--- a/src/boj_stat_search/shell/catalog/search.py
+++ b/src/boj_stat_search/shell/catalog/search.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -137,7 +138,15 @@ def resolve_db(
         if not cache_path.exists():
             continue
 
-        table = pq.read_table(cache_path)
+        try:
+            table = pq.read_table(cache_path)
+        except Exception as exc:
+            warnings.warn(
+                f"resolve_db: skipping unreadable cache file for {db_name} "
+                f"at {cache_path}: {exc}",
+                stacklevel=2,
+            )
+            continue
         if "series_code" not in table.column_names:
             continue
 


### PR DESCRIPTION
## Summary

- `resolve_db` in `search.py` now wraps `pq.read_table(cache_path)` in `try/except Exception`; on failure it issues `warnings.warn` and continues to the next DB instead of crashing
- A corrupted file is now treated analogously to a missing file or one lacking a `series_code` column — skipped silently but visibly
- The existing "no cached catalog files found" `CatalogCacheError` at the end naturally covers the all-corrupted case

Closes #43

## Test plan

- [x] `test_resolve_db_skips_corrupted_cache_and_finds_match_in_later_db` — garbage bytes in `db1`, valid cache in `db2`; asserts correct DB returned and warning emitted
- [x] `test_resolve_db_warns_on_corrupted_cache_file` — only a corrupted file; asserts warning emitted and `CatalogCacheError` raised
- [x] `uv run pytest -q tests/test_catalog_search.py -k resolve_db` → 12 passed
- [x] `uv run ruff check src tests` → all checks passed
- [x] `uv run ruff format --check src tests` → 34 files already formatted
- [x] `uv run ty check` → all checks passed
- [x] `uv run pytest -q` → 241 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)