### PR TITLE
feat: extract pure error parsing and DB resolution logic into core (#42)

### DIFF
--- a/docs/development_guide/architecture.md
+++ b/docs/development_guide/architecture.md
@@ -15,7 +15,9 @@ src/boj_stat_search/
 │   ├── models/
 │   │   └── __init__.py
 │   ├── database.py
+│   ├── error_parser.py
 │   ├── formatter.py
+│   ├── request_planner.py
 │   ├── parser.py
 │   ├── types.py
 │   ├── url_builder.py

--- a/src/boj_stat_search/core/__init__.py
+++ b/src/boj_stat_search/core/__init__.py
@@ -1,3 +1,5 @@
+from boj_stat_search.core.error_parser import BojErrorFields, parse_error_payload
+from boj_stat_search.core.request_planner import pick_first_code_for_db_resolution
 from boj_stat_search.core.catalog_parser import (
     REQUIRED_COLUMNS,
     ensure_required_columns,
@@ -29,6 +31,9 @@ from boj_stat_search.core.validator import (
 )
 
 __all__ = [
+    "BojErrorFields",
+    "parse_error_payload",
+    "pick_first_code_for_db_resolution",
     "REQUIRED_COLUMNS",
     "ensure_required_columns",
     "resolve_db_from_tables",

--- a/src/boj_stat_search/core/error_parser.py
+++ b/src/boj_stat_search/core/error_parser.py
@@ -1,0 +1,30 @@
+from typing import Any, NamedTuple
+
+
+class BojErrorFields(NamedTuple):
+    boj_status: int | None
+    message_id: str | None
+    boj_message: str | None
+
+
+def parse_error_payload(payload: dict[str, Any]) -> BojErrorFields:
+    raw_status = payload.get("STATUS")
+    if raw_status in (None, ""):
+        boj_status = None
+    else:
+        try:
+            boj_status = int(raw_status)
+        except (TypeError, ValueError):
+            boj_status = None
+
+    raw_message_id = payload.get("MESSAGEID")
+    message_id = str(raw_message_id) if raw_message_id not in (None, "") else None
+
+    raw_message = payload.get("MESSAGE")
+    boj_message = str(raw_message) if raw_message not in (None, "") else None
+
+    return BojErrorFields(
+        boj_status=boj_status,
+        message_id=message_id,
+        boj_message=boj_message,
+    )

--- a/src/boj_stat_search/core/request_planner.py
+++ b/src/boj_stat_search/core/request_planner.py
@@ -1,0 +1,15 @@
+from boj_stat_search.core.types import Code, Db
+from boj_stat_search.core.validator import coerce_code, extract_db_from_code
+
+
+def pick_first_code_for_db_resolution(db: Db | str | None, code: Code | str | None) -> str | None:
+    """Return the first series code to use for DB auto-resolution, or None if not needed."""
+    if db is not None:
+        return None
+    if extract_db_from_code(code) is not None:
+        return None
+    normalized_code = coerce_code(code)
+    if not isinstance(normalized_code, str):
+        return None
+    first_code = normalized_code.split(",", 1)[0].strip()
+    return first_code if first_code else None

--- a/tests/core/test_error_parser.py
+++ b/tests/core/test_error_parser.py
@@ -1,0 +1,67 @@
+from boj_stat_search.core.error_parser import BojErrorFields, parse_error_payload
+
+
+def test_normal_payload():
+    result = parse_error_payload({"STATUS": "100", "MESSAGEID": "E001", "MESSAGE": "Not found"})
+    assert result == BojErrorFields(boj_status=100, message_id="E001", boj_message="Not found")
+
+
+def test_empty_dict():
+    result = parse_error_payload({})
+    assert result == BojErrorFields(boj_status=None, message_id=None, boj_message=None)
+
+
+def test_empty_string_status():
+    result = parse_error_payload({"STATUS": "", "MESSAGEID": "E002", "MESSAGE": "Error"})
+    assert result.boj_status is None
+    assert result.message_id == "E002"
+    assert result.boj_message == "Error"
+
+
+def test_non_numeric_status():
+    result = parse_error_payload({"STATUS": "abc"})
+    assert result.boj_status is None
+
+
+def test_numeric_string_status():
+    result = parse_error_payload({"STATUS": "404"})
+    assert result.boj_status == 404
+
+
+def test_missing_messageid():
+    result = parse_error_payload({"STATUS": "200", "MESSAGE": "OK"})
+    assert result.message_id is None
+
+
+def test_missing_message():
+    result = parse_error_payload({"STATUS": "200", "MESSAGEID": "M01"})
+    assert result.boj_message is None
+
+
+def test_non_string_value_coercion():
+    result = parse_error_payload({"STATUS": 500, "MESSAGEID": 42, "MESSAGE": 99})
+    assert result.boj_status == 500
+    assert result.message_id == "42"
+    assert result.boj_message == "99"
+
+
+def test_extra_keys_ignored():
+    result = parse_error_payload(
+        {"STATUS": "200", "MESSAGEID": "M01", "MESSAGE": "OK", "EXTRA": "ignored"}
+    )
+    assert result == BojErrorFields(boj_status=200, message_id="M01", boj_message="OK")
+
+
+def test_none_status():
+    result = parse_error_payload({"STATUS": None})
+    assert result.boj_status is None
+
+
+def test_empty_messageid_treated_as_none():
+    result = parse_error_payload({"MESSAGEID": ""})
+    assert result.message_id is None
+
+
+def test_empty_message_treated_as_none():
+    result = parse_error_payload({"MESSAGE": ""})
+    assert result.boj_message is None

--- a/tests/core/test_request_planner.py
+++ b/tests/core/test_request_planner.py
@@ -1,0 +1,50 @@
+from boj_stat_search.core.request_planner import pick_first_code_for_db_resolution
+from boj_stat_search.core.types import Code, Db
+
+
+def test_returns_none_when_db_provided():
+    result = pick_first_code_for_db_resolution(db="FM01", code="STRDCLUCON")
+    assert result is None
+
+
+def test_returns_none_when_db_enum_provided():
+    result = pick_first_code_for_db_resolution(db=Db.FM01, code="STRDCLUCON")
+    assert result is None
+
+
+def test_returns_none_when_code_has_embedded_db():
+    code = Code("FM01'STRDCLUCON")
+    result = pick_first_code_for_db_resolution(db=None, code=code)
+    assert result is None
+
+
+def test_returns_code_for_simple_string():
+    result = pick_first_code_for_db_resolution(db=None, code="STRDCLUCON")
+    assert result == "STRDCLUCON"
+
+
+def test_returns_first_code_for_comma_separated():
+    result = pick_first_code_for_db_resolution(db=None, code="STRDCLUCON,STRACLUCON")
+    assert result == "STRDCLUCON"
+
+
+def test_returns_none_for_none_code():
+    result = pick_first_code_for_db_resolution(db=None, code=None)
+    assert result is None
+
+
+def test_returns_none_for_empty_string():
+    result = pick_first_code_for_db_resolution(db=None, code="")
+    assert result is None
+
+
+def test_returns_code_value_for_code_object_without_db():
+    code = Code("STRDCLUCON")
+    result = pick_first_code_for_db_resolution(db=None, code=code)
+    assert result == "STRDCLUCON"
+
+
+def test_returns_first_code_value_for_multi_code_object_without_db():
+    code = Code("STRDCLUCON", "STRACLUCON")
+    result = pick_first_code_for_db_resolution(db=None, code=code)
+    assert result == "STRDCLUCON"


### PR DESCRIPTION
## Summary

- Moves BOJ error payload dict-parsing into `core/error_parser.py` (`BojErrorFields`, `parse_error_payload`)
- Moves DB auto-resolution decision logic into `core/request_planner.py` (`pick_first_code_for_db_resolution`)
- `shell/api.py` delegates to both; removes now-unused `coerce_code`/`extract_db_from_code` imports
- Re-exports new symbols from `core/__init__.py`
- Updates `docs/development_guide/architecture.md` directory tree

## Test plan

- [x] `uv run pytest -q` — 265 passed
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ty check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)